### PR TITLE
`api.check.is_preview_pane` now works with multiple inboxes enabled

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -62,12 +62,14 @@ var Gmail =  function() {
     var dom = api.dom.inbox_content();
     var boxes = dom.find("[gh=tl]");
 
-    var isPreviewPane = false;
+    var previewPaneFound = false;
     boxes.each(function() {
-      if ($(this).hasClass('aia')) isPreviewPane = true;
+      if($(this).hasClass('aia')) {
+        previewPaneFound = true;
+      }
     });
 
-    return isPreviewPane;
+    return previewPaneFound;
   }
 
 


### PR DESCRIPTION
This check was previously failing for people who had the "multiple inboxes" lab enabled, because the code was only checking `box[0]` but it was possible the user's first "box" wouldn't have a preview pane showing.
