### PR TITLE
Correct xobni function name

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -227,7 +227,7 @@ var Gmail =  function() {
   }
 
 
-  api.check.is_xobini_installed = function() {
+  api.check.is_xobni_installed = function() {
     return $('#xobni_frame').length > 0;
   }
 


### PR DESCRIPTION
Looks like the name should be: is_xobni_installed
