### PR TITLE
Returning a jQuery selector from `api.dom.email_subject`

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -129,11 +129,11 @@ var Gmail =  function() {
   
     for(var i=0; i<e.length; i++) {
       if($(e[i]).is(':visible')) {
-        return e[i];
+        return $(e[i]);
       }
     };
   
-    return null;
+    return $();
   }
 
 


### PR DESCRIPTION
For consistency's sake, the `api.dom.email_subject` function should return a jQuery selector rather than a raw DOM element.
