### PR TITLE
Added api.get.compose_ids()

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -195,7 +195,17 @@ var Gmail =  function() {
     }
     return [];
   }
-
+  
+  api.get.compose_ids = function() {
+	  var ret = [];
+	  var dom = $(".AD [name=draft]");
+	  for (var i = 0; i < dom.length; i++) {
+		  if(dom[i].value != "undefined"){
+			  ret.push(dom[i].value);
+		  }
+	  };
+	  return ret;
+  }
 
   api.get.email_id = function() {
     var hash = null;


### PR DESCRIPTION
This function gets the Email Ids of the compose Emails that have been saved.

This ignores the new drafts that have not been saved
