### PR TITLE
made api.observe.on method accepts callback for gmail's post response

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -697,7 +697,9 @@ var Gmail =  function() {
             response.push(api.tools.parse_response(progress.target.responseText));
             api.tracker.response_watchdog[action_map[action]].apply(undefined, response);
           }
-          if (curr_onreadystatechange) {curr_onreadystatechange.apply(this, arguments)}
+          if (curr_onreadystatechange) {
+            curr_onreadystatechange.apply(this, arguments);
+          }
         }
       }
 


### PR DESCRIPTION
changes in response to issue https://github.com/KartikTalwar/gmail.js/issues/54

Some informations are only available in gmail's post response data.
Like the Email id of a newly sent email, this is not available on send_message post params.

sample usage:

``` javascript
function responseCallback(url, body, data, response_data) {
    var email_id = response_data[2][1][3][0];
    var emailURL = '#inbox/' + email_id;
    if (window.location.hash !== emailURL) {
         setTimeout(function() {
             window.location.hash = emailURL; // opens the thread of the email, 
         }, 200)
    }
}
gmail.observe.on('send_message', function(url, body, data){}, responseCallback); 
```

So far the changes is working well with my use case. But please review the way I overrided the onreadystatechange and added the hook on it. I'm not too familiar with xhr methods and afraid that the way I did is not safe and would break others relying on the onreadystatechange method.
