### PR TITLE
Avoid jQuery/$ incompatibilities with scripts injected by third parties

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1,21 +1,14 @@
-var gmailGlobalJquery;
-if (typeof jQuery !== "undefined")
-  gmailGlobalJquery = jQuery;
-
-var Gmail = function(localJquery) {
+var Gmail = function(localJQuery) {
 
   /*
-    Use provided jQuery if possible, in order to avoid conflicts with
+    Use the provided 'jQuery' if possible, in order to avoid conflicts with
     other extensions that use $ for other purposes.
-    If not provided as an argument, we ensure that we capture the jQuery
-    that is currently defined. Other extensions can later redefine
-    the global jQuery or $ without affecting us.
   */
   var $;
-  if (typeof localJquery !== "undefined")
-    $ = localJquery;
-  else if (typeof gmailGlobalJquery !== "undefined")
-    $ = gmailGlobalJquery;
+  if (typeof localJQuery !== "undefined")
+    $ = localJQuery;
+  else if (typeof jQuery !== "undefined")
+    $ = jQuery;
   // else leave $ undefined, which may be fine for some purposes.
 
   var api = {


### PR DESCRIPTION
This feature allows us to coexist with other Gmail extensions that rebind the global `$` identifier to something that is not jQuery.

The change is compatible with existing code, except if jQuery was loaded after the call to the main Gmail() function, which I believe would be a strange thing to do.

See inline comments for details.
