### PR TITLE
Added condition to prevent functions from being parsed.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1067,7 +1067,9 @@ var Gmail = function(localJQuery) {
     var emails = [];
 
     for(i in api.tracker.view_data) {
-      if (typeof(api.tracker.view_data[i]) === 'function') { continue; }
+      if (typeof(api.tracker.view_data[i]) === 'function') {
+        continue;
+      }
 
       var cdata = api.tools.parse_view_data(api.tracker.view_data[i]);
       if(cdata.length > 0) {


### PR DESCRIPTION
Streak uses `bacon.js` which subscribes to XHR calls and adds a function and it's being parsed in loop. This prevents it.
