### PR TITLE
Add missing all_subjects dom definition into compose object

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1725,6 +1725,7 @@ var Gmail =  function() {
         id: 'input[name=composeid]',
         subject: 'input[name=subject]',
         subjectbox: 'input[name=subjectbox]',
+        all_subjects: 'input[name=subjectbox], input[name=subject]',
         body: 'div[contenteditable=true]',
         reply: 'M9',
         forward: 'M9',


### PR DESCRIPTION
all_subjects was not defined in gmail.dom.compose object's dom method
resulting in updating subject to throw an error. Fixes #98
