### PR TITLE
Retrieve the correct localization.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -59,7 +59,7 @@ var Gmail = function(localJQuery) {
 
 
   api.get.localization = function() {
-    return api.tracker.globals[17][9][8];
+    return api.tracker.globals[17][8][8];
   };
 
 


### PR DESCRIPTION
[17][9][8] returns 'US' regardless of display language. [17][8][8] returns 'en', 'da', etc.
