### PR TITLE
Adding handling for show_newly_arrived_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,12 +756,12 @@ gmail.observe.on("delete_forever", function(id, url, body, xhr) {
   console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
 })
 
-gmail.observe.on("delete_message_in_thread", function(id, url, body, xhr) {
-  console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
+gmail.observe.on("delete_message_in_thread", function(id, url, body) {
+  console.log("id:", id, "url:", url, 'body', body);
 })
 
-gmail.observe.on("restore_message_in_thread", function(id, url, body, xhr) {
-  console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
+gmail.observe.on("restore_message_in_thread", function(id, url, body) {
+  console.log("id:", id, "url:", url, 'body', body);
 })
 
 gmail.observe.on("star", function(id, url, body, xhr) {
@@ -820,8 +820,8 @@ gmail.observe.on("delete_label", function(id, url, body, xhr) {
   console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
 })
 
-gmail.observe.on("show_newly_arrived_message", function(id, url, body, xhr) {
-  console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
+gmail.observe.on("show_newly_arrived_message", function(id, url, body) {
+  console.log("id:", id, "url:", url, 'body', body);
 })
 
 gmail.observe.on("poll", function(url, body, data, xhr) {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -693,6 +693,7 @@ var Gmail = function(localJQuery) {
 
       case "dm":
       case "rtr":
+      case "mo":
         response = [sent_params.m, params.url, params.body];
         break;
 


### PR DESCRIPTION
It looks like the 'show_newly_arrived_message' event currently isn't being handled. This pull request addresses that issue. 

Detailed description of this fix: 
It turns out the response object was not being populated when the 'mo' event is being handled. This results in no event handlers being triggered, due to the conditional in line 745 that checks for a non-null response. It's entirely possible this event should be handled another way; however, I found the approach taken in this pull request to be reliable and useful. It reliably captures the id of the newly arrived message, along with the url and body. 

If you decide to go ahead with merging this pull request, the README should be updated to reflect that listeners for this event should only expect three parameters: the id, url, and body.