### PR TITLE
get reply_to email

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ The data does not come from the DOM
   "threads": {
     "141d44da39d6caf8": {
       "reply_to_id": "",
+      "reply_to": "replytome@gmail.com",
       "is_deleted" : false,
       "from": "California",
       "to" : ["hi@kartikt.com"],
@@ -294,6 +295,7 @@ The data does not come from the DOM
   "threads": {
     "141d44da39d6caf8": {
       "reply_to_id": "",
+      "reply_to": null,
       "is_deleted" : false,
       "from": "California",
       "to" : ["hi@kartikt.com"],
@@ -332,6 +334,7 @@ the data for the specified id is returned instead of the email currently visible
   "threads": {
     "141d44da39d6caf8": {
       "reply_to_id": "",
+      "reply_to": "replytome@gmail.com",
       "is_deleted" : false,
       "from": "California",
       "to" : ["hi@kartikt.com"],
@@ -367,6 +370,7 @@ Returns an object representation of the emails that are being displayed.
   "threads": {
     "145881e7a8befff6": {
       "reply_to_id": "",
+      "reply_to": "replytome@gmail.com",
       "is_deleted" : false,
       "from": "California",
       "to" : ["hi@kartikt.com"],

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1555,6 +1555,19 @@ var Gmail = function(localJQuery) {
     }, 0);
   }
 
+  api.tools.get_reply_to = function(ms13) {
+    // reply to is an array if exists
+    var reply_to = (ms13 != undefined) ? ms13[4] : [];
+
+    // if reply to set get email from it and return it
+    if (reply_to.length !== 0) {
+      return api.tools.extract_email_address(reply_to[0]);
+    }
+
+    // otherwise return undefined
+    return;
+  }
+
   api.tools.parse_email_data = function(email_data) {
     var data = {};
     var threads = {}
@@ -1589,6 +1602,7 @@ var Gmail = function(localJQuery) {
         data.threads[x[1]].to = (x[13] != undefined) ? x[13][1] : ((x[37] != undefined) ? x[37][1]:[]);
         data.threads[x[1]].cc = (x[13] != undefined) ? x[13][2] : [];
         data.threads[x[1]].bcc = (x[13] != undefined) ? x[13][3] : [];
+        data.threads[x[1]].reply_to = api.tools.get_reply_to(x[13]);
 
         try { // jQuery will sometime fail to parse x[13][6], if so, putting the raw HTML
           data.threads[x[1]].content_plain = (x[13] != undefined) ? $(x[13][6]).text() : x[8];

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1564,8 +1564,8 @@ var Gmail = function(localJQuery) {
       return api.tools.extract_email_address(reply_to[0]);
     }
 
-    // otherwise return undefined
-    return;
+    // otherwise return null
+    return null;
   }
 
   api.tools.parse_email_data = function(email_data) {


### PR DESCRIPTION
Hi, I needed reply-to email for my extension so I got it this way.

I'm not sure its the best way tough cause [13][4] is an array and I'm not sure if reply to can be multiple addresses but I took into consideration only one. I couldn't find a way to get more as gmail and all other providers allow only one reply to.

Please take a look and let me know if there is a better way, I'll gladly update. This is something I see could be useful for lot of people.

Thanks!