### PR TITLE
Check that email is visible when looking up email_id in preview pane mode

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -270,7 +270,8 @@ var Gmail = function(localJQuery) {
         for(var i=0; i<items.length; i++) {
           var mail_id = items[i].getAttribute('class').split(' ')[2];
           var is_editable = items[i].getAttribute('contenteditable');
-          if(mail_id != 'undefined' && mail_id != undefined) {
+          var is_visible = items[i].offsetWidth > 0 && items[i].offsetHeight > 0;
+          if(mail_id != 'undefined' && mail_id != undefined && is_visible) {
             if(is_editable != 'true') {
               text.push(mail_id);
             }


### PR DESCRIPTION
`gmail.get.email_id()` returns the id for the wrong email when in preview_pane mode. This seems to happen because [`api.dom.email_contents()`](https://github.com/KartikTalwar/gmail.js/blob/master/src/gmail.js#L267) returns all emails that have been viewed by the user when in preview pane mode and `email_id` only [returns the first one](https://github.com/KartikTalwar/gmail.js/blob/master/src/gmail.js#L280).