### PR TITLE
Added generic http observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ gmail.get.user_email();
 - [gmail.observe**.register(action, class/args, parent)**](#gmailobserveregisteraction-classargs-parentnull) - registers a custom DOM observer
 - [gmail.observe**.off(action,type)**](#gmailobserveoffactionnulltypenull)
 - [gmail.observe**.on(action, callback)**](#gmailobserveonaction-callback)
+  - **`http_event`** - When gmail any CRUD operation happens on gmail
   - **`poll`** - When gmail automatically polls the server to check for new emails every few seconds
   - **`new_email`** - When a new email appears in the inbox
   - **`open_email`** - When an email is opened from the inbox view
@@ -170,7 +171,6 @@ gmail.get.user_email();
 - [gmail.observe**.before(action, callback)**](#gmailobservebeforeaction-callback)
 - [gmail.observe**.after(action, callback)**](#gmailobserveafteraction-callback)
 - gmail.observe**.bind(type, action, callback)** - implements the on, after, before callbacks
-- gmail.observe**.bound(action, type)**
 - gmail.observe**.on_dom(action, callback)** - implements the DOM observers - called by `gmail.observe.on`
 - gmail.observe**.bound(action, type)** - checks if a specific action and/or type has any bound observers
 - gmail.observe**.trigger(type, events, xhr)** - fires any specified events for this type (on, after, before) with specified parameters
@@ -666,6 +666,7 @@ Your callback will be fired directly after Gmail's XMLHttpRequest has been sent 
 
 **Available Actions**
 
+  - **http_event** - When gmail any CRUD operation happens on gmail
   - **poll** - When gmail automatically polls the server to check for new emails every few seconds
   - **new_email** - When a new email appears in the inbox
   - **open_email** - When a new email appears in the inbox
@@ -725,6 +726,10 @@ gmail.observe.on('view_email', function(obj) {
   - **load_email_menu** - When the dropdown menu next to the reply button is clicked
 
 ```js
+gmail.observe.on("http_event", function(params) {
+  console.log("url data:", params);
+})
+
 gmail.observe.on("unread", function(id, url, body, xhr) {
   console.log("id:", id, "url:", url, 'body', body, 'xhr', xhr);
 })

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -596,10 +596,6 @@ var Gmail = function(localJQuery) {
       return params.body_is_object && api.observe.bound('upload_attachment') ? { upload_attachment: [ params.body_params ] } : false; // trigger attachment event
     }
 
-    if(params.method == 'POST' && typeof params.url.act == 'string') {
-      // console.log(params.url, params.body);
-    }
-
     if(params.url.search != undefined) {
       // console.log(params.url, params.body, params.url_raw);
     }
@@ -744,9 +740,17 @@ var Gmail = function(localJQuery) {
         triggered.refresh = response;
       }
     }
+
     if(response && action_map[action] && api.observe.bound(action_map[action])) {
       triggered[action_map[action]] = response;
     }
+
+    if(params.method == 'POST' && (typeof params.url.SID == 'string'
+                                   || typeof params.url.ik == 'string'
+                                   || typeof params.url.act == 'string')) {
+      triggered.http_event = [params]; // send every event and all data
+    }
+
     return triggered;
   }
 


### PR DESCRIPTION
You can now use `http_event` observer which executes your call back on all POST http events. This includes almost all actions on gmail related to message modification and retrieval. If you have any other observer running, this method would execute the callback again

#153 