### PR TITLE
Prevent double-encoding

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1362,7 +1362,7 @@ var Gmail = function(localJQuery) {
 
 
   api.tools.make_request = function (link, method) {
-
+    link = decodeURIComponent(link);
     var method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
     var request = $.ajax({ type: method, url: encodeURI(link), async:false });
 


### PR DESCRIPTION
Added logic to prevent double-encoding of a url
Without it, it sends an invalid string to gmail when calling `get.visible_emails` with an email address as the search string (because the @ is first encoded as `%40`, which then gets encoded again as `%2540`)