### PR TITLE
Capture draft-open case

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1468,7 +1468,7 @@ var Gmail = function(localJQuery) {
   }
 
   api.get.current_page = function() {
-    var hash  = window.location.hash.split('#').pop();
+    var hash  = window.location.hash.split('#').pop().split('?').shift();
     var pages = ['sent', 'inbox', 'starred', 'drafts', 'imp', 'chats', 'all', 'spam', 'trash', 'settings'];
 
     var page = null;


### PR DESCRIPTION
Taking into considering locations like `https://mail.google.com/mail/u/0/#inbox?compose=14d2b386bebbfff1`  
This is needed when making calls to `gmail.get.visible_emails()`, from the above path, otherwise `api.get.current_page()` returns null, resulting in an `indexOf` error on line #1408