### PR TITLE
Fixed api.get.current_page

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1506,7 +1506,7 @@ var Gmail = function(localJQuery) {
   }
 
   api.get.current_page = function() {
-    var hash  = window.location.hash.split('#').pop().split('?').shift();
+    var hash  = window.location.hash.split('#').pop().split('?').shift().split("/").pop();
     var pages = ['sent', 'inbox', 'starred', 'drafts', 'imp', 'chats', 'all', 'spam', 'trash', 'settings'];
 
     var page = null;


### PR DESCRIPTION
At some point, Gmail started to use slashes the start of the hash and this broke the `api.get.current_page` call. 