### PR TITLE
Fixed issue where HTML Comments were causing error spam in api.tools.insertion_observer

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1313,6 +1313,9 @@ var Gmail = function(localJQuery) {
     //console.log('insertion', target, target.className);
     if(!api.tracker.dom_observer_map) return;
 
+    // comments will not have this attribute, but still count as dom insertion, causing un-needed errors
+    if(!target.className) return;
+
     // loop through each of the inserted elements classes & check for a defined observer on that class
     var classes = target.className.trim().split(/\s+/);
     if(!classes.length) classes.push(''); // if no class, then check for anything observing nodes with no class

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1509,7 +1509,9 @@ var Gmail = function(localJQuery) {
   }
 
   api.get.current_page = function() {
-    var hash  = window.location.hash.split('#').pop().split('?').shift().split("/").pop();
+    var hash  = window.location.hash.split('#').pop().split('?').shift();
+    if (hash.charAt(0) === '/') hash = hash.slice(1);
+
     var pages = ['sent', 'inbox', 'starred', 'drafts', 'imp', 'chats', 'all', 'spam', 'trash', 'settings'];
 
     var page = null;


### PR DESCRIPTION
HTML Comments are weird in that they have the attribute for `className`, but it's undefined. This PR fixes an issue where HTML comments being inserted into DOM would cause errors to appear in the console.
