### PR TITLE
Added the abiliy to extract draft email id from compose windows

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2076,12 +2076,18 @@ var Gmail = function(localJQuery) {
     return this;
   }
   $.extend(api.dom.compose.prototype, {
-
     /**
       Retrieve the compose id
      */
     id: function() {
       return this.dom('id').val();
+    },
+
+    /**
+      Retrieve the draft email id
+     */
+    email_id: function() {
+      return this.dom('draft').val();
     },
 
     /**
@@ -2173,6 +2179,7 @@ var Gmail = function(localJQuery) {
         cc:'textarea[name=cc]',
         bcc:'textarea[name=bcc]',
         id: 'input[name=composeid]',
+        draft: 'input[name=draft]',
         subject: 'input[name=subject]',
         subjectbox: 'input[name=subjectbox]',
         all_subjects: 'input[name=subjectbox], input[name=subject]',


### PR DESCRIPTION
This feature is useful if you want to access the draft using Gmail API, for example: https://developers.google.com/gmail/api/v1/reference/users/drafts/get