### PR TITLE
add a MutationObserver to handle and trigger recipient_change event o…

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1285,11 +1285,10 @@ var Gmail = function(localJQuery) {
             var removedNodes = mutation.removedNodes;
             for (var j = 0; j < removedNodes.length; j++) {
               var removedNode = removedNodes[j];
-              console.log(removedNode);
               if (removedNode.className == 'vR') {
                 var observer = api.tracker.dom_observer_map['vR'];
                 var handler = api.tracker.dom_observers.recipient_change.handler;
-                api.observe.trigger_dom(observer, $(removedNode), handler);
+                api.observe.trigger_dom(observer, $(mutation.target), handler);
               }
             }
           }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1277,6 +1277,25 @@ var Gmail = function(localJQuery) {
         $(window.document).bind('DOMNodeInserted', function(e) {
           api.tools.insertion_observer(e.target, api.tracker.dom_observers, api.tracker.dom_observer_map);
         });
+
+        // recipient_change also needs to listen to removals
+        var mutationObserver = new MutationObserver(function(mutations) {
+          for (var i = 0; i < mutations.length; i++) {
+            var mutation = mutations[i];
+            var removedNodes = mutation.removedNodes;
+            for (var j = 0; j < removedNodes.length; j++) {
+              var removedNode = removedNodes[j];
+              console.log(removedNode);
+              if (removedNode.className == 'vR') {
+                var observer = api.tracker.dom_observer_map['vR'];
+                var handler = api.tracker.dom_observers.recipient_change.handler;
+                api.observe.trigger_dom(observer, $(removedNode), handler);
+              }
+            }
+          }
+        });
+        mutationObserver.observe($('div.dw')[0], {subtree: true, childList: true});
+
       }
       api.observe.bind('dom',action,callback);
       // console.log(api.tracker.observing_dom,'dom_watchdog is now:',api.tracker.dom_watchdog);

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1293,7 +1293,7 @@ var Gmail = function(localJQuery) {
             }
           }
         });
-        mutationObserver.observe($('div.dw')[0], {subtree: true, childList: true});
+        mutationObserver.observe(document.body, {subtree: true, childList: true});
 
       }
       api.observe.bind('dom',action,callback);


### PR DESCRIPTION
…n receipient remove from compose interface - fix #119

This gets the basic functionality that I need working, but guessing you might have suggestions for changes?

Don't really like listening on such a high level element, but not sure what would be better? Should I just register on the `document` instead?