### PR TITLE
add method to api.dom.compose to get the from email address - helpful…

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2155,6 +2155,21 @@ var Gmail = function(localJQuery) {
       return subject ? subject : this.dom('subject').val();
     },
 
+    /** 
+      Get the from email
+      if user only has one email account they can send from, returns that email address
+      */
+    from: function() {
+      var el = this.dom('from');
+      if (el.length) {
+        var fromNameAndEmail = el.val();
+        if (fromNameAndEmail) {
+          return gmail.tools.extract_email_address(fromNameAndEmail);
+        }
+      }
+      return gmail.get.user_email();
+    },
+
     /**
       Get/Set the email body
      */
@@ -2187,7 +2202,8 @@ var Gmail = function(localJQuery) {
         all_subjects: 'input[name=subjectbox], input[name=subject]',
         body: 'div[contenteditable=true]',
         reply: 'M9',
-        forward: 'M9'
+        forward: 'M9',
+        from: 'input[name=from]'
       };
       if(!config[lookup]) api.tools.error('Dom lookup failed. Unable to find config for \'' + lookup + '\'',config,lookup,config[lookup]);
       return this.$el.find(config[lookup]);


### PR DESCRIPTION
… if a user has multiple addresses they can send from

Not sure how many users have multiple emails they can send from, but it's not that uncommon - I'd like to be able to do this. It's a little trickier to set than get, so this method just gets (and that's all I need at the moment - I'd be happy to add setting if people think that would be worthwhile). 