### PR TITLE
added local scope for var i in iterator

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -46,7 +46,7 @@ var Gmail = function(localJQuery) {
     var data = api.tracker.globals[17][23];
     var users = [];
 
-    for(i in data[1]) {
+    for(var i in data[1]) {
       users.push({name : data[1][i][4], email : data[1][i][0]})
     }
 


### PR DESCRIPTION
As advised for Firefox reviewer, better add `var` for the iterator.