### PR TITLE
Fix `Uncaught TypeError` in api.tools.insertion_observer

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1332,7 +1332,8 @@ var Gmail = function(localJQuery) {
     if(!api.tracker.dom_observer_map) return;
 
     // loop through each of the inserted elements classes & check for a defined observer on that class
-    var classes = target.className.trim().split(/\s+/);
+    var className = target.className;
+    var classes = className ? className.trim().split(/\s+/) : [];
     if(!classes.length) classes.push(''); // if no class, then check for anything observing nodes with no class
     $.each(classes, function(idx, className) {
       var observer = dom_observer_map[className];


### PR DESCRIPTION
When the target node has no className property, such as for a `comment` node, gmail.js will throw an `Uncaught TypeError`.  This commit guards against that case.

[Fixes #218]