### PR TITLE
Change is_inside_email to reflect the changes on 8d74d82

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -203,7 +203,7 @@ var Gmail = function(localJQuery) {
 
 
   api.check.is_inside_email = function() {
-    if(api.get.current_page() != null && !api.check.is_preview_pane()) {
+    if(api.get.current_page() != 'email' && !api.check.is_preview_pane()) {
       return false;
     }
 


### PR DESCRIPTION
After 8d74d82 `current_page` returns `'email'` instead of `null` if the user is inside an email