### PR TITLE
Don't mess with the target node

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1252,7 +1252,8 @@ var Gmail =  function() {
     if(!api.tracker.dom_observer_map) return;
     
     // loop through each of the inserted elements classes & check for a defined observer on that class
-    var classes = target.className.trim().split(/\s+/);
+    var cn = target.className || '';
+    var classes = cn.trim().split(/\s+/);
     if(!classes.length) classes.push(''); // if no class, then check for anything observing nodes with no class
     $.each(classes, function(idx, className) {
       var observer = dom_observer_map[className];


### PR DESCRIPTION
In some occasions nodes don't have a className defined which causes an error to be thrown. Don't mess with the actual DOM to default it as inserting a ClassName into target nodes causes strange bugs in the email editor (e.g. removing formatting).