### PR TITLE
email_id returns an empty string in a message popup window

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -363,9 +363,11 @@ var Gmail = function(localJQuery) {
       } else {
         hash = window.location.hash.split("/").pop().replace(/#/, '').split('?')[0];
       }
-
     }
-
+    else {
+      hash = api.tools.parse_url(window.location.href).type;
+    }
+    
     return hash;
   }
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -365,7 +365,7 @@ var Gmail = function(localJQuery) {
       }
     }
     else {
-      hash = api.tools.parse_url(window.location.href).type;
+      hash = api.tools.parse_url(window.location.href).th;
     }
     
     return hash;


### PR DESCRIPTION
When a message is popped out using the ‘In new window’ icon located next to the ‘Print all’ icon adjacent to the subject line the email_id isn’t calculated properly