### PR TITLE
Fix not getting the correct id element.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2337,7 +2337,7 @@ var Gmail = function(localJQuery) {
 
     // if no id specified, extract from the body wrapper class (starts with 'm' followed by the id)
     if (!this.id) {
-      this.id_element = element.find('div.ii.gt');
+      this.id_element = element.find('div.ii.gt > .a3s');
       this.id = this.id_element.attr('class').match(/(^|\s)m([\S]*)/).pop();
     }
     this.$el = element;


### PR DESCRIPTION
Gmail seems to have changed where the id element is, giving a cannot read property pop of element null error with the old selector.