### PR TITLE
Fix query failure if chat is disabled

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -197,7 +197,12 @@ var Gmail = function(localJQuery) {
 
 
   api.check.is_right_side_chat = function() {
-    return $('.ApVoH')[0].getAttribute('aria-labelledby') == ':wf';
+    var chat = $('.ApVoH');
+    if(chat.length === 0) {
+      return false;
+    }
+
+    return chat[0].getAttribute('aria-labelledby') == ':wf';
   }
 
   api.check.should_compose_fullscreen = function(){


### PR DESCRIPTION
When querying for the chat box in order to report ```is_right_side_chat```, a ```.getAttribute``` lookup on the query will evaluate to undefined, causing an error.

The error can be circumvented by checking the length of the chat box query first, and if it's disabled,  return false immediately.