### PR TITLE
Removing original XMLHttpRequest from prototype to protect it as a gl…

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -919,17 +919,16 @@ var Gmail_ = function(localJQuery) {
 
 
   api.tools.xhr_watcher = function () {
-
     if (!api.tracker.xhr_init) {
       api.tracker.xhr_init = true;
       var win = top.document.getElementById("js_frame") ? top.document.getElementById("js_frame").contentDocument.defaultView : window.opener.top.document.getElementById("js_frame").contentDocument.defaultView;
 
-      if (!win.XMLHttpRequest.prototype._gjs_open) {
-        win.XMLHttpRequest.prototype._gjs_open = win.XMLHttpRequest.prototype.open;
+      if (!win.gjs_XMLHttpRequest_open) {
+        win.gjs_XMLHttpRequest_open = win.XMLHttpRequest.prototype.open;
       }
 
       win.XMLHttpRequest.prototype.open = function (method, url, async, user, password) {
-        var out = win.XMLHttpRequest.prototype._gjs_open.apply(this, arguments);
+        var out = win.gjs_XMLHttpRequest_open.apply(this, arguments);
         this.xhrParams = {
           method: method.toString(),
           url: url.toString()
@@ -937,8 +936,8 @@ var Gmail_ = function(localJQuery) {
         return out;
       };
 
-      if (!win.XMLHttpRequest.prototype._gjs_send) {
-        win.XMLHttpRequest.prototype._gjs_send = win.XMLHttpRequest.prototype.send;
+      if (!win.gjs_XMLHttpRequest_send) {
+        win.gjs_XMLHttpRequest_send = win.XMLHttpRequest.prototype.send;
       }
 
       win.XMLHttpRequest.prototype.send = function (body) {
@@ -973,7 +972,7 @@ var Gmail_ = function(localJQuery) {
         }
 
         // send the original request
-        var out = this._gjs_send.apply(this, arguments);
+        var out = win.gjs_XMLHttpRequest_send.apply(this, arguments);
 
         // fire on events
         api.observe.trigger('on', events, this);


### PR DESCRIPTION
This makes the original XMLHttpRequest object's send and open methods part of a new global object on the window so that other extensions that may overwrite the native XMLHttpRequest object will not interfere with the wrapped version.

Background: Previously, if InboxSDK came in after an extension that uses gmail.js was loaded and installed any xhr observers, then it would overwrite the entire XMLHttpRequest object and clobber those (Overwrite new members added: _gjs_open/_gjs_send to the prototype and make them undefined). This would break gmail, since the undefined errors would cause this code to crash and never run the async requests properly.