### PR TITLE
Corect default method

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1469,7 +1469,7 @@ var Gmail_ = function(localJQuery) {
 
   api.tools.make_request = function (link, method) {
     link = decodeURIComponent(link);
-    method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
+    method  = method || 'GET';
 
     var request = $.ajax({ type: method, url: encodeURI(link), async:false });
 
@@ -1479,7 +1479,7 @@ var Gmail_ = function(localJQuery) {
 
   api.tools.make_request_async = function (link, method, callback) {
     link = decodeURIComponent(link);
-    method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
+    method  = method || 'GET';
 
     $.ajax({ type: method, url: encodeURI(link), async:true, dataType: 'text' })
       .done(function(data, textStatus, jqxhr) {
@@ -2584,3 +2584,4 @@ function initalizeOnce(fn) {
   }
 }
 
+	


### PR DESCRIPTION
Using Google bigquery I found that your code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it would compare to a string with the content `'undefined'`

As I could see you just want to have a default value of `method` i simply replaced the code with a shorter/better version...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kartiktalwar/gmail.js/303)

<!-- Reviewable:end -->
