### PR TITLE
Adding the ability to detect when undo_send is clicked

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -694,6 +694,7 @@ var Gmail_ = function(localJQuery) {
                       'tae'         : 'add_to_tasks',
                       'rc_^i'       : 'archive',
                       'tr'          : 'delete',
+                      'cs'          : 'undo_send',
                       'dm'          : 'delete_message_in_thread',
                       'dl'          : 'delete_forever',
                       'dc_'         : 'delete_label',
@@ -744,6 +745,7 @@ var Gmail_ = function(localJQuery) {
     var response    = null;
 
     switch(action) {
+      case "cs":
       case "ur":
       case "rd":
       case "tr":


### PR DESCRIPTION
As we discussed here https://github.com/KartikTalwar/gmail.js/issues/201 

Pressing the button can be detected using he 

    gmail.observe.on('undo_send', function (url, body, data, xhr) {
        console.log(body, body.m);
        console.log(xhr);
    });

`body.m` holds the message id if needed.