### PR TITLE
Updated make_request function to get raw massage from the new show_original page format of Gmail

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1473,8 +1473,11 @@ var Gmail_ = function(localJQuery) {
     method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
 
     var request = $.ajax({ type: method, url: encodeURI(link), async:false });
-
-    return request.responseText;
+    var parser = new DOMParser();
+    var doc = parser.parseFromString(request.responseText, "text/html");
+    var elem = doc.getElementById("raw_message_text");
+    var source = elem.innerHTML;
+    return source;
   };
 
 


### PR DESCRIPTION
Gmail.js API using tools.make_request function to visit the show_original page to get the email source. Since Gmail changed that page format from raw message to different html format i made some changes in the make request function to get only the raw massage.
