### PR TITLE
Determine current page as email if ending with messageID && keep encoded number-sign in URLs

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1660,6 +1660,9 @@ var Gmail_ = function(localJQuery) {
     if(hash.indexOf('inbox/') !== -1) {
       page = 'email';
     }
+    else if(hash.match(/\/[0-9a-f]{16,}$/gi)) {
+      page = 'email';
+    }
 
     return page || hash;
   };

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1536,7 +1536,7 @@ var Gmail_ = function(localJQuery) {
     var url = window.location.origin + window.location.pathname + '?ui=2&ik=' + api.tracker.ik+'&rid=' + api.tracker.rid + '&view=tl&num=120&rt=1';
     if (!!$('.Dj:visible').find("b:first").text()) {
       url += '&start=' + + parseInt($('.Dj:visible').find("b:first").text() - 1) + 
-        '&sstart=' + parseInt($('.Dj:visible').find("b:first").text() - 1);
+        '&start=' + parseInt($('.Dj:visible').find("b:first").text() - 1);
     } else {
       url += '&start=0';
     }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1469,27 +1469,29 @@ var Gmail_ = function(localJQuery) {
   };
 
 
-  api.tools.make_request = function (link, method) {
-    link = decodeURIComponent(link);
+  api.tools.make_request = function (_link, method) {
+    var link = decodeURIComponent(_link.replace(/%23/g, "#-#-#"));
     method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
 
-    var request = $.ajax({ type: method, url: encodeURI(link), async:false });
+    link = encodeURI(link).replace(/#-#-#/gi, "%23");
+    var request = $.ajax({ type: method, url: link, async:false });
 
     return request.responseText;
   };
 
 
-  api.tools.make_request_async = function (link, method, callback) {
-    link = decodeURIComponent(link);
+  api.tools.make_request_async = function (_link, method, callback) {
+    var link = decodeURIComponent(_link.replace(/%23/g, "#-#-#"));
     method  = (typeof method == undefined || typeof method == null) ? 'GET' : method;
 
-    $.ajax({ type: method, url: encodeURI(link), async:true, dataType: 'text' })
-      .done(function(data, textStatus, jqxhr) {
-        callback(jqxhr.responseText);
-      })
-      .fail(function(jqxhr, textStatus, errorThrown) {
-        console.error('Request Failed', errorThrown);
-      });
+    link = encodeURI(link).replace(/#-#-#/gi, "%23");
+    $.ajax({ type: method, url: link, async:true, dataType: 'text' })
+        .done(function(data, textStatus, jqxhr) {
+          callback(jqxhr.responseText);
+        })
+        .fail(function(jqxhr, textStatus, errorThrown) {
+          console.error('Request Failed', errorThrown);
+        });
   };
 
 


### PR DESCRIPTION
Sometimes, the URLs for ajax requests contain encoded number-signs (%23 = #) which is decoded by the ajax functions and therefore the request fails:

Original: https://mail.google.com/...&rid=mail%3A%23.b81c.23.5&view=tl&...
Encoded: https://mail.google.com/...&rid=mail:#.b81c.23.5&view=tl&...

My code replaces all occurrences of %23 by a placeholder, decodes the URL, encodes it and replaces the placeholder with %23.

----------

The current_page function does not reliably determine if the user has opened an email.
If the user is inside an email, the URL ends with a slash + hexadecimal string of minimum 16 characters.