### PR TITLE
Revert "Fix bug: to get ID of an item with actived Preview pane, we need sear…"

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -354,7 +354,7 @@ var Gmail_ = function(localJQuery) {
         var text = [];
 
         for(var i=0; i<items.length; i++) {
-          var mail_id = items[i].children[0].getAttribute('class').split(' ')[2];
+          var mail_id = items[i].getAttribute('class').split(' ')[2];
           var is_editable = items[i].getAttribute('contenteditable');
           var is_visible = items[i].offsetWidth > 0 && items[i].offsetHeight > 0;
           if(mail_id != 'undefined' && mail_id != undefined && is_visible) {


### PR DESCRIPTION
Reverts KartikTalwar/gmail.js#298

Tested with and without preview pane mode.

<img width="741" alt="screen shot 2016-10-23 at 10 47 02 am" src="https://cloud.githubusercontent.com/assets/2517811/19623247/2cb6cfcc-990e-11e6-9d16-9259a3b30d37.png">

cc @KartikTalwar, @Navega 
