### PR TITLE
Make gmail.js loadable through NodeJS and require()

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -15,8 +15,15 @@ var Gmail_ = function(localJQuery) {
     $ = localJQuery;
   } else if (typeof jQuery !== "undefined") {
     $ = jQuery;
+  } else {
+    // try load jQuery through node.
+    try {
+      $ = require("jquery");
+    }
+    catch(err) {
+      // else leave $ undefined, which may be fine for some purposes.
+    }
   }
-  // else leave $ undefined, which may be fine for some purposes.
 
   var api = {
               get : {},
@@ -2576,11 +2583,7 @@ var Gmail_ = function(localJQuery) {
   return api;
 };
 
-if (!window.Gmail) {
-  window.Gmail = initalizeOnce(Gmail_);
-}
-
-function initalizeOnce(fn) {
+function initializeOnce(fn) {
   var result;
   return function() {
     if (fn) {
@@ -2588,6 +2591,15 @@ function initalizeOnce(fn) {
     }
     fn = null;
     return result;
-  }
+  };
 }
 
+// required to avoid error in NodeJS.
+var GmailClass = initializeOnce(Gmail_);
+if (typeof(window) !== "undefined" && !window.Gmail) {
+    window.Gmail = GmailClass;
+}
+
+// make class accessible to require()-users.
+exports = exports || {};
+exports.Gmail = GmailClass;


### PR DESCRIPTION
This commit makes it possible to load gmail.s through node.

This is useful for use with browserify and other systems where modules can import dependencies declaratively and have it all resolved before loading in the browser.

For gmail.js to work in node 3 things has been done:

- avoid explicit window-references until value is checked.
- make Gmail-instance accessible through exports.
- automatically resolve own jQuery-dependency through node if possible.