### PR TITLE
Updated unread_inbox_emails to parse properly when Gmail has the "Unread items in the first section and inbox, for example (2 : 3)" option set

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -469,8 +469,8 @@ var Gmail_ = function(localJQuery) {
     var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n('inbox') + "']");
 
     if(dom.length > 0) {
-      if(dom[0].text.indexOf('(') != -1) {
-        return parseInt(dom[0].text.replace(/[^0-9]/g, ''));
+      if(dom[0].text.indexOf('(') != -1) { 
+        return parseInt(dom[0].text.split(':')[0].replace(/[^0-9]/g, ''));
       }
     }
 


### PR DESCRIPTION
When using priority inbox the unread count in the gmail UI can be setup to display two counts in the format `(10 : 20)`. At present this parses as `1020` rather than `10`.

Example on gmail...
<img width="170" alt="screen shot 2016-11-12 at 08 30 39" src="https://cloud.githubusercontent.com/assets/103586/20236610/73737c0e-a8b2-11e6-911f-6820ed816b66.png">

Settings to configure this behaviour...
![5675335c-a66b-11e6-8eea-abeaea9567ee](https://cloud.githubusercontent.com/assets/103586/20236611/87765c94-a8b2-11e6-948b-63982c7c1e36.png)

This pull request splits the count by colon first and takes the first value to return the correct value
