### PR TITLE
Email source CORS fix

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -228,9 +228,9 @@ interface GmailGet {
     */
     email_source(email_id: string): string;
     /**
-       Does the same as email_source but accepts a callback function
+       Does the same as email_source but accepts a callback and an optional error_callback function
     */
-    email_source_async(email_id: string, callback: (email_source: string) => void): void;
+    email_source_async(email_id: string, callback: (email_source: string) => void, error_callback: (jqxhr, textStatus: string, errorThrown: string) => void): void;
     displayed_email_data(): GmailEmailData;
 
 }
@@ -555,8 +555,8 @@ interface GmailTools {
     */
     insertion_observer(target: HTMLElement | string, dom_observers: any, dom_observer_map: any, sub: any);
 
-    make_request(link: string, method: GmailHttpRequestMethod): string;
-    make_request_async(link: string, method: GmailHttpRequestMethod, callback: (data: string) => void);
+    make_request(link: string, method: GmailHttpRequestMethod, disable_cache: boolean): string;
+    make_request_async(link: string, method: GmailHttpRequestMethod, callback: (data: string) => void, disable_cache: boolean);
     parse_view_data(view_data: any[]): any[];
     /**
        Adds the yellow info box on top of gmail with the given message

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -302,9 +302,7 @@ var Gmail_ = function(localJQuery) {
         for(var i=0; i<items.length; i++) {
             var mail_id = items[i].getAttribute("class").split(" ")[2];
             if(mail_id !== "undefined" && mail_id !== undefined) {
-                if($(items[i]).is(":visible")) {
-                    ids.push(items[i]);
-                }
+                ids.push(items[i]);
             }
         }
 


### PR DESCRIPTION
As already noticed by @josteink in the merged PR https://github.com/KartikTalwar/gmail.js/pull/329 there is a CORS problem when the browser caches the first redirect. 

Although it seems that the location of the redirect is the same when requested 'fresh' but Google only supplies the `Access-Control-Allow-Origin` header for the latter. Strangely!!! Btw, this might also happen in other places so if you see CORS related errors check that the cache is not used. And of course to learn from this... do not disable cache in devtools when testing gmail.js! ;)

jQuery's `{cache: false}` adds something like this to the url `_=76348726487` which might not be OK for all GET calls so I've added the flag on `make_request` and `make_request_async`.

I've also added a change to `is_inside_email` because when email text is hidden (collapsed because of thread already read) it should return `true`.
This happens for example when someone emails an attachment as a reply on an email but without adding text.

This fixes an issue in my application and I don't see any problems but if you don't want to add it I'll make you a new PR if you want.

The `TODO` probably needs to looked at because I see some errors (not a lot) coming in from my extension in production.