### PR TITLE
fix is_inside_email when email text is hidden/collapsed

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -302,9 +302,7 @@ var Gmail_ = function(localJQuery) {
         for(var i=0; i<items.length; i++) {
             var mail_id = items[i].getAttribute("class").split(" ")[2];
             if(mail_id !== "undefined" && mail_id !== undefined) {
-                if($(items[i]).is(":visible")) {
-                    ids.push(items[i]);
-                }
+                ids.push(items[i]);
             }
         }
 


### PR DESCRIPTION
Fix for `is_inside_email` because when email text is hidden (collapsed because of thread already read) it should return true.

This happens for example when someone emails an attachment as a reply on an email but without adding text.

I don't see when we might want to check for that visibility but it probably did have a reason when it was added (a long time ago btw).

Ideas anyone?

@josteink as discussed in https://github.com/KartikTalwar/gmail.js/pull/333
