### PR TITLE
Email source cors cache

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -228,9 +228,9 @@ interface GmailGet {
     */
     email_source(email_id: string): string;
     /**
-       Does the same as email_source but accepts a callback function
+       Does the same as email_source but accepts a callback and an optional error_callback function
     */
-    email_source_async(email_id: string, callback: (email_source: string) => void): void;
+    email_source_async(email_id: string, callback: (email_source: string) => void, error_callback: (jqxhr, textStatus: string, errorThrown: string) => void): void;
     displayed_email_data(): GmailEmailData;
 
 }
@@ -555,8 +555,8 @@ interface GmailTools {
     */
     insertion_observer(target: HTMLElement | string, dom_observers: any, dom_observer_map: any, sub: any);
 
-    make_request(link: string, method: GmailHttpRequestMethod): string;
-    make_request_async(link: string, method: GmailHttpRequestMethod, callback: (data: string) => void);
+    make_request(link: string, method: GmailHttpRequestMethod, disable_cache: boolean): string;
+    make_request_async(link: string, method: GmailHttpRequestMethod, callback: (data: string) => void, disable_cache: boolean);
     parse_view_data(view_data: any[]): any[];
     /**
        Adds the yellow info box on top of gmail with the given message

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1547,7 +1547,7 @@ var Gmail_ = function(localJQuery) {
             .fail(function(jqxhr, textStatus, errorThrown) {
                 console.error("Request Failed", errorThrown);
                 if (typeof error_callback === 'function'){
-                    error_callback(jqxhr, textStatus, errorThrown)
+                    error_callback(jqxhr, textStatus, errorThrown);
                 }
             });
     };

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -955,7 +955,6 @@ var Gmail_ = function(localJQuery) {
     api.tools.xhr_watcher = function () {
         if (!api.tracker.xhr_init) {
             api.tracker.xhr_init = true;
-            // TODO(michi88): what to do when window.opener === null? (i've seen this in production errors)
             var win = top.document.getElementById("js_frame") ? top.document.getElementById("js_frame").contentDocument.defaultView : window.opener.top.document.getElementById("js_frame").contentDocument.defaultView;
 
             if (!win.gjs_XMLHttpRequest_open) {


### PR DESCRIPTION
New PR as discussed in https://github.com/KartikTalwar/gmail.js/pull/333

---

As already noticed by @josteink in the merged PR #329 there is a CORS problem when the browser caches the first redirect.

Although it seems that the location of the redirect is the same when requested 'fresh' but Google only supplies the `Access-Control-Allow-Origin` header for the latter. Strangely!!! Btw, this might also happen in other places so if you see CORS related errors check that the cache is not used. And of course to learn from this... do not disable cache in devtools when testing gmail.js! ;)

jQuery's `{cache: false}` adds something like this to the url `_=76348726487` which might not be OK for all GET calls so I've added the flag on `make_request` and `make_request_async`.