### PR TITLE
start parameter calculation change at visible_emails_pre function

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1591,9 +1591,11 @@ var Gmail_ = function(localJQuery) {
     api.helper.get.visible_emails_pre = function() {
         var page = api.get.current_page();
         var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&num=120&rt=1";
-        if ($(".Dj:visible").find("b:first").text()) {
-            url += "&start=" + parseInt($(".Dj:visible").find("b:first").text() - 1) +
-                "&start=" + parseInt($(".Dj:visible").find("b:first").text() - 1);
+        var start = $(".aqK:visible .Dj").find("span:first").text().replace(",", "");
+        if (start) {
+            start = parseInt(start - 1);
+            url += "&start=" + start +
+                   "&start=" + start;
         } else {
             url += "&start=0";
         }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1595,7 +1595,7 @@ var Gmail_ = function(localJQuery) {
         if (start) {
             start = parseInt(start - 1);
             url += "&start=" + start +
-                   "&start=" + start;
+                   "&sstart=" + start;
         } else {
             url += "&start=0";
         }


### PR DESCRIPTION
The markup for email's pagination has been changed at gmail recently:

![image](https://cloud.githubusercontent.com/assets/17640566/20562988/855ac42a-b197-11e6-8545-864c34f6ff5d.png)

Was:
`<span class="Dj"><b>111</b>–<b>114</b> of <b>114</b></span>`
New:
`<span class="Dj"><span class="ts">111</span>–<span class="ts">114</span> of <span class="ts">114</span></span>`

Also if there are more than 1000 emails the number may be "1,234". The ` .replace(",", "")` has been added to fix it. 

Note: i don't know why we need duplicated start parameter. 