### PR TITLE
is_deleted sometimes is not calculated correctly

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1851,7 +1851,7 @@ var Gmail_ = function(localJQuery) {
                 }
 
                 data.threads[x[1]] = {};
-                data.threads[x[1]].is_deleted = x[13] === undefined;
+                data.threads[x[1]].is_deleted = x[13] ? true : false;
                 data.threads[x[1]].reply_to_id = x[2];
                 data.threads[x[1]].from = x[5];
                 data.threads[x[1]].from_email = x[6];
@@ -1859,18 +1859,18 @@ var Gmail_ = function(localJQuery) {
                 data.threads[x[1]].datetime = x[24];
                 data.threads[x[1]].attachments = x[21].split(",");
                 data.threads[x[1]].subject = x[12];
-                data.threads[x[1]].content_html = (x[13] !== undefined) ? x[13][6] : x[8];
-                data.threads[x[1]].to = (x[13] !== undefined) ? x[13][1] : ((x[37] !== undefined) ? x[37][1]:[]);
-                data.threads[x[1]].cc = (x[13] !== undefined) ? x[13][2] : [];
-                data.threads[x[1]].bcc = (x[13] !== undefined) ? x[13][3] : [];
+                data.threads[x[1]].content_html = x[13] ? x[13][6] : x[8];
+                data.threads[x[1]].to = x[13] ? x[13][1] : ((x[37] !== undefined) ? x[37][1]:[]);
+                data.threads[x[1]].cc = x[13] ? x[13][2] : [];
+                data.threads[x[1]].bcc = x[13] ? x[13][3] : [];
                 data.threads[x[1]].reply_to = api.tools.get_reply_to(x[13]);
                 data.threads[x[1]].labels = x[9];
 
                 try { // jQuery will sometime fail to parse x[13][6], if so, putting the raw HTML
-                    data.threads[x[1]].content_plain = (x[13] !== undefined) ? $(x[13][6]).text() : x[8];
+                    data.threads[x[1]].content_plain = x[13] ? $(x[13][6]).text() : x[8];
                 }
                 catch(e) {
-                    data.threads[x[1]].content_plain = (x[13] !== undefined) ? x[13][6] : x[8];
+                    data.threads[x[1]].content_plain = x[13] ? x[13][6] : x[8];
                 }
             }
         }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1864,6 +1864,7 @@ var Gmail_ = function(localJQuery) {
                 data.threads[x[1]].cc = (x[13] !== undefined) ? x[13][2] : [];
                 data.threads[x[1]].bcc = (x[13] !== undefined) ? x[13][3] : [];
                 data.threads[x[1]].reply_to = api.tools.get_reply_to(x[13]);
+                data.threads[x[1]].labels = x[9];
 
                 try { // jQuery will sometime fail to parse x[13][6], if so, putting the raw HTML
                     data.threads[x[1]].content_plain = (x[13] !== undefined) ? $(x[13][6]).text() : x[8];


### PR DESCRIPTION
When the email is deleted the x[13] is returned null from sever:
![image](https://cloud.githubusercontent.com/assets/17640566/20599744/db311664-b260-11e6-80a7-b95938ddd63a.png)
Thus the comparison `(x[13] === underfined) ?` is not enough for this case. And due to this there is a scenario when the gmail.get.displayed_email_data() throws an error: 

1. In a email thread remove email
2. Execute gmail.get.displayed_email_data() call
Error: 
`gmail.js:1862 Uncaught TypeError: Cannot read property '6' of null(…)
Gmail_.api.tools.parse_email_data 
@ gmail.js:1862Gmail_.api.helper.get.email_data_post 
@ gmail.js:1906Gmail_.api.get.email_data 
@ gmail.js:1915Gmail_.api.get.displayed_email_data 
@ gmail.js:1969(anonymous function) 
@ VM1028:1`

![image](https://cloud.githubusercontent.com/assets/17640566/20599515/86acce68-b25f-11e6-82e3-4645e8321ef6.png)

To fix that the the `api.tools.parse_email_data` method has been updated: `(x[13] === underfined) ?` replaced with comparison with `x[13] ?`

Also the `data.threads[x[1]].labels = x[9];` has been added to be able to retrieve the labels for the email. 
