### PR TITLE
Added api.get.displayed_email_data_async, updated is_deleted calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 0.6.4
+
+- Fix `api.get.displayed_email_data` when email text is deleted
+
 ## Version 0.6.3
 
 - Fix `api.check.is_inside_email` when email text is hidden/collapsed

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ gmail.get.user_email();
 - [gmail.get**.email_data(email_id=undefined)**](#gmailgetemail_dataemail_idundefined)
 - [gmail.get**.email_data_async(email_id=undefined, callback)**](#gmailgetemail_dataemail_idundefined-callback)
 - [gmail.get**.displayed_email_data()**](#gmailgetdisplayed_email_data)
+- [gmail.get**.displayed_email_data_async(callback)**](#gmailgetdisplayed_email_data_asynccallback)
 - [gmail.get**.email_source(email_id=undefined)**](#gmailgetemail_sourceemail_idundefined)
 - [gmail.get**.email_source_async(email_id=undefined, callback)**](#gmailgetemail_sourceemail_idundefined-callback)
 - [gmail.get**.search_query()**](#gmailgetsearch_query)
@@ -421,6 +422,11 @@ Returns an object representation of the emails that are being displayed.
 }
 
 ```
+
+#### gmail.get.displayed_email_data_async(callback)
+
+Does the same as above but accepts a callback function
+
 
 #### gmail.get.email_source(email_id=undefined)
 

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -231,7 +231,15 @@ interface GmailGet {
        Does the same as email_source but accepts a callback and an optional error_callback function
     */
     email_source_async(email_id: string, callback: (email_source: string) => void, error_callback: (jqxhr, textStatus: string, errorThrown: string) => void): void;
+    /**
+     Retrieves the a email/thread data from the server that is currently
+     visible.  The data does not come from the DOM.
+     */
     displayed_email_data(): GmailEmailData;
+    /**
+     Does the same as displayed_email_data, but with a callback instead.
+     */
+    displayed_email_data_async(callback: (gmailEmailData: GmailEmailData) => void): void;
 
 }
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1851,7 +1851,7 @@ var Gmail_ = function(localJQuery) {
                 }
 
                 data.threads[x[1]] = {};
-                data.threads[x[1]].is_deleted = x[13] ? true : false;
+                data.threads[x[1]].is_deleted = (x[9] && x[9].indexOf("^k") > -1);
                 data.threads[x[1]].reply_to_id = x[2];
                 data.threads[x[1]].from = x[5];
                 data.threads[x[1]].from_email = x[6];

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1976,6 +1976,17 @@ var Gmail_ = function(localJQuery) {
         }
     };
 
+    api.get.displayed_email_data_async = function (email_id, isCollapsed, isDeleted, callback) {
+        api.get.email_data_async(email_id, function (email_data) {
+            if (api.check.is_conversation_view()) {
+                callback(get_displayed_email_data_for_thread(email_data));
+            }
+            else { // Supposing only one displayed email.
+                callback(get_displayed_email_data_for_single_email(email_data));
+            }
+        });
+    };
+
     var get_displayed_email_data_for_thread = function(email_data) {
         var displayed_email_data = email_data;
 


### PR DESCRIPTION
It has been noticed that if the `x[13] ` is `null` it does not mean the message is deleted. For e.g. the `x[13]` may be `null` if it is collapsed or the message is plaintext and very small. 

But as far i can see if if the message contains the `"^k"` label it means that the message is actually deleted.
![image](https://cloud.githubusercontent.com/assets/17640566/20603870/90643990-b274-11e6-978c-9e63d8f4878b.png)

Thus the change is to set `is_deleted` flag based on the existence of "^k" label. 
Also the `api.get.displayed_email_data_async` has been added.

