### PR TITLE
Fix CORS issues for api.get.email_source()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## Version 0.6.10
+
+- Introduce `api.get.email_source_promise`.
+- Deprecate `api.get.email_source`.
+- Support downloading email-source in binary format.
+
 ## Version 0.6.9
 
 - Fix potential NPE in `api.check.is_plain_text`.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ gmail.get.user_email();
 - [gmail.get**.email_data_async(email_id=undefined, callback)**](#gmailgetemail_dataemail_idundefined-callback)
 - [gmail.get**.displayed_email_data()**](#gmailgetdisplayed_email_data)
 - [gmail.get**.displayed_email_data_async(callback)**](#gmailgetdisplayed_email_data_asynccallback)
-- [gmail.get**.email_source(email_id=undefined)**](#gmailgetemail_sourceemail_idundefined)
-- [gmail.get**.email_source_async(email_id=undefined, callback)**](#gmailgetemail_sourceemail_idundefined-callback)
+- [gmail.get**.email_source_async(email_id=undefined, callback, error_callback, preferBinary)**](#gmailgetemail_source_asyncemail_idundefined-callback-error_callback-preferBinaryfalse)
+- [gmail.get**.email_source_promise(email_id=undefined, preferBinary)**](#gmailgetemail_source_promiseemail_idundefined-preferBinaryfalse)
 - [gmail.get**.search_query()**](#gmailgetsearch_query)
 - [gmail.get**.unread_emails()**](#gmailgetunread_emails)
  - [gmail.get**.unread_inbox_emails()**](#gmailgetunread_emails)
@@ -240,6 +240,7 @@ These are some helper functions that the rest of the methods use. See source for
 - gmail.tools**.extract_name(str)**
 - gmail.tools**.make_request()**
 - gmail.tools**.make_request_async()**
+- gmail.tools**.make_request_download_promise(url, preferBinary)** - function specialized for downloading email MIME messages or attachments.
 - gmail.tools**.sleep(ms)**
 - gmail.tools**.multitry(ms_delay, tries, func, bool_success_check)**
 - gmail.tools**.i18n(label)**
@@ -462,13 +463,30 @@ Does the same as above but accepts a callback function.
 
 #### gmail.get.email_source(email_id=undefined)
 
+Deprecated function. Will be removed. Migrate to
+`gmail.get.email_source_async` or `gmail.get.email_source_promise`
+instead.
+
+#### gmail.get.email_source_async(email_id=undefined, callback, error_callback, preferBinary=false)
+
 Retrieves raw MIME message source from the gmail server for the specified email id. It takes the optional email_id parameter where
 the data for the specified id is returned instead of the email currently visible in the dom
 
+By default, once retrieved the resulting data will be passed to
+`callback` in text-format. **This may corrupt the actual email
+MIME-data, by causing irreversible content-encoding
+consistency-errors.**
 
-#### gmail.get.email_source_async(email_id=undefined, callback)
+If you need to parse this data in a proper MIME-parser later, the only
+way to avoid this kind of error is to download the data in binary
+format and do your own decoding inside your own MIME-parser.
 
-Does the same as above but accepts a callback function
+To get the email-source in binary form, you must set the
+`preferBinary`-parameter to `true`.
+
+#### gmail.get.email_source_promise(email_id=undefined, preferBinary=false)
+
+Does the same as above but implements it using ES6 promises.
 
 
 #### gmail.get.user_email()
@@ -811,7 +829,7 @@ gmail.observe.on('view_thread', function(obj) {
   console.log('view_thread', obj);
 });
 
-// now we have access to the sub observers 
+// now we have access to the sub observers
 and load_email_menu
 gmail.observe.on('view_email', function(obj) {
   console.log('view_email', obj);
@@ -1280,6 +1298,7 @@ for (let attachment of attachments) {
                 i => i.name === attachment.name
             )[0];
             console.log("This attachment has URL: " + attachment_details.url);
+            // download using api.tools.make_request_download_promise!
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gmail-js",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "description": "JavaScript API for Gmail (useful for chrome extensions)",
     "main": "src/gmail.js",
     "types": "src/gmail.d.ts",

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -238,16 +238,25 @@ interface GmailGet {
     */
     email_data_async(email_id: string, callback: (email_data: GmailEmailData) => void): void;
     /**
-       Retrieves raw MIME message source from the gmail server for the
-       specified email id. It takes the optional email_id parameter
-       where the data for the specified id is returned instead of the
-       email currently visible in the dom
+       Deprecated function. Migrate to `email_source_async` or `email_source_promise`!
     */
     email_source(email_id: string): string;
     /**
-       Does the same as email_source but accepts a callback and an optional error_callback function
+       Retrieves raw MIME message source from the gmail server for the
+       specified email id. It takes the optional email_id parameter
+       where the data for the specified id is returned instead of the
+       email currently visible in the dom.
+
+       The `callback` is invoked with the resulting data in either
+       string or binary format depending on the value of the
+       `preferBinary`-parameter.
     */
-    email_source_async(email_id: string, callback: (email_source: string) => void, error_callback?: (jqxhr, textStatus: string, errorThrown: string) => void): void;
+    email_source_async(email_id: string, callback: (email_source: string | Uint8Array) => void, error_callback?: (jqxhr, textStatus: string, errorThrown: string) => void, preferBinary?: boolean): void;
+    /**
+       Does the same as email_source_async, but uses ES6 promises.
+    */
+    email_source_promise(email_id: string): Promise<string>;
+    email_source_promise(email_id: string, preferBinary: boolean): Promise<Uint8Array>;
     /**
      Retrieves the a email/thread data from the server that is currently
      visible.  The data does not come from the DOM.
@@ -599,6 +608,17 @@ interface GmailTools {
 
     make_request(link: string, method: GmailHttpRequestMethod, disable_cache: boolean): string;
     make_request_async(link: string, method: GmailHttpRequestMethod, callback: (data: string) => void, disable_cache: boolean);
+
+    /**
+       Creates a request to download user-content from Gmail.
+       This can be used to download email_source or attachments.
+
+       Set `preferBinary` to receive data as an Uint8Array which is unaffected
+       by string-parsing or resolving of text-encoding.
+
+       This is required in order to correctly download attachments!
+    */
+    make_request_download_promise(link: string, preferBinary?: boolean): Promise<string> | Promise<Uint8Array>;
     parse_view_data(view_data: any[]): any[];
     /**
        Adds the yellow info box on top of gmail with the given message

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2059,16 +2059,15 @@ var Gmail_ = function(localJQuery) {
 
 
     api.helper.get.email_source_pre = function(email_id) {
-        if(api.check.is_inside_email() && email_id === undefined) {
+        if(!email_id && api.check.is_inside_email()) {
             email_id = api.get.email_id();
         }
 
-        var url = null;
-        if(email_id !== undefined) {
-            url = window.location.origin + window.location.pathname + "?view=att&th=" + email_id + "&attid=0&disp=comp&safe=1&zw";
+        if(!email_id) {
+            return null;
         }
 
-        return url;
+        return window.location.origin + window.location.pathname + "?view=att&th=" + email_id + "&attid=0&disp=comp&safe=1&zw";
     };
 
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2073,7 +2073,7 @@ var Gmail_ = function(localJQuery) {
 
 
     api.get.email_source = function(email_id) {
-        console.warn("Gmail.js: This function has been deprecated and will be removed in a upcoming release! Please migrate to email_source_asnc!");
+        console.warn("Gmail.js: This function has been deprecated and will be removed in an upcoming release! Please migrate to email_source_async!");
         var url = api.helper.get.email_source_pre(email_id);
         if (url !== null) {
             return api.tools.make_request(url, "GET", true);

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2093,10 +2093,7 @@ var Gmail_ = function(localJQuery) {
             return api.tools.make_request_download_promise(url, preferBinary);
         } else {
             return new Promise((resolve, reject) => {
-                // I honestly don't think this makes sense.  We really
-                // should reject the promise, but that would break
-                // backward compatibility W.R.T. _async...
-                resolve("");
+                reject("Unable to resolve URL for email source!");
             });
         }
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,5 @@
-{} 
+{
+    "compilerOptions": {
+        "target": "es6"
+    }
+}


### PR DESCRIPTION
This commit does quite a few things all in one, which is counter to regular "git philosophy", but all in all, I think they belong together.

The changes can be summed up as:

1. Deprecate `api.get.email_source()` - Displays warning for now. Will remove it once we hit 0.7.0.
2. Added new function for downloading "troublesome" content like attachments and email MIME-source. This function is currently *only* used for this.
3. Add extra parameter to `api.get.email_source_async()` to allow downloading in binary form to avoid introducing encoding errors in MIME-messages.
4. Started migrating to more ES6ish constructs. Arrow-functions, `const`s, block-scoped `let`s etc. Updated corresponding linting/compilation settings. It was about time :)
5. Updated documentation.
6. Updated typescript-definitions.
7. Bumped version.
8. Updated changelog.

*phew*

Downloading email source is now verified to work in ALL modern browsers (Sorry Safari!). This fixes https://github.com/KartikTalwar/gmail.js/issues/353.

@michi88 , @KartikTalwar : I'll await your response before doing anything else (merging this to `master`) Ideally, this being a PR and all, I'm not the one doing the merging :)

Noteworthy: The part about introducing ES6 concepts will make the library *slightly* inconsistent API-wise when this is merged. Therefore, once all other issues have been settled, and this PR has been merged, I'd like to brush up some other parts of the library to also use more modern JS-concepts:

* Also provide Promises everywhere we have currently async-methods.
* Make consistent usage of `const` and `let` where appropriate.

Sounds OK?

(I'd also *love* to separate out the singleton implementation thing into its "own thing", so that we can convert Gmail.js itself to use proper classes, and what not. But I guess that will be its own big project some time in the future, *if* I have time and incentive to do so.)