### PR TITLE
Regex - hyphen must be last or escaped by a backslash

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2212,7 +2212,7 @@ var Gmail_ = function(localJQuery) {
 
 
     api.tools.extract_name = function(str) {
-        var regex = /[a-z"._-\s]+/gi;
+        var regex = /[a-z"._\s-]+/gi;
         var matches = (str) ? str.match(regex) : undefined;
 
         return (matches && matches[0]) ? matches[0].trim() : undefined;


### PR DESCRIPTION
This bugs the function