### PR TITLE
Fix issues for api.get.visible_emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ const gmail = new GmailFactory.Gmail() as Gmail;
 - [gmail.get**.visible_emails_async(callback)**](#gmailgetvisible_emailscallback)
 - [gmail.get**.selected_emails_data()**](#gmailgetselected_emails_data)
 - [gmail.get**.current_page()**](#gmailgetcurrent_page)
+- [gmail.get**.emails_per_page()**](#gmailgetemails_per_page)
 - [gmail.get**.email_id()**](#gmailgetemail_id)
 - [gmail.get**.email_ids()**](#gmailgetemail_ids)
 - [gmail.get**.email_subject()**](#gmailgetemail_subject)
@@ -549,6 +550,14 @@ Returns what page of gmail the user is currently on. These are the possible resp
 "/label/[.+]" // inside label view
 "/category/[.+]" // inside category view
 "/settings/[.+]" // settings sub-page (excluding settings root page)
+```
+
+#### gmail.get.emails_per_page()
+
+Returns the number of emails shown per page
+
+```js
+50
 ```
 
 #### gmail.get.email_subject()

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -184,7 +184,7 @@ interface GmailGet {
        Returns a count of total unread emails for the current account.
 
        You can also request the data individually using:
-       
+
        gmail.get.unread_inbox_emails()
        gmail.get.unread_draft_emails()
        gmail.get.unread_spam_emails()
@@ -222,6 +222,10 @@ interface GmailGet {
        Returns what page of gmail the user is currently on.
      */
     current_page(): GmailPageType;
+    /**
+       Returns the number of emails shown per page
+     */
+    emails_per_page(): number;
     /**
        Returns an object representation of the opened email contents
        and metadata. It takes the optional email_id parameter where
@@ -723,7 +727,7 @@ interface GmailObserve {
        This is the key feature of gmail.js. This method allows you to
        add triggers to all of these actions so you can build your
        custom extension/tool with this library.
-       
+
        You simply specify the action name and your function that the
        method will return data to when the actions are triggered and
        it does the rest. You can have multiple triggers

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1695,7 +1695,7 @@ var Gmail_ = function(localJQuery) {
 
     api.helper.get.visible_emails_pre = function() {
         var page = api.get.current_page();
-        var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&rt=1&num=" + (api.tracker.globals[8] || 100);
+        var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&rt=1&num=" + api.get.emails_per_page();
         var start = $(".aqK:visible .Dj").find("span.ts:first").text().replace(",", "").replace(".", "");
         if (start) {
             url += "&start=" + parseInt(start - 1);
@@ -1846,6 +1846,11 @@ var Gmail_ = function(localJQuery) {
             result = parts[0] + "/" + parts[1];
             return result;
         }
+    };
+
+
+    api.get.emails_per_page = function() {
+        return api.tracker.globals[8] || 100;
     };
 
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1695,12 +1695,10 @@ var Gmail_ = function(localJQuery) {
 
     api.helper.get.visible_emails_pre = function() {
         var page = api.get.current_page();
-        var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&num=120&rt=1";
-        var start = $(".aqK:visible .Dj").find("span:first").text().replace(",", "").replace(".", "");
+        var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&rt=1&num=" + (api.tracker.globals[8] || 100);
+        var start = $(".aqK:visible .Dj").find("span.ts:first").text().replace(",", "").replace(".", "");
         if (start) {
-            start = parseInt(start - 1);
-            url += "&start=" + start +
-                   "&sstart=" + start;
+            url += "&start=" + parseInt(start - 1);
         } else {
             url += "&start=0";
         }


### PR DESCRIPTION
'visible_emails' always returns the first 120 emails. This patch changes
2 string query params in the URL of the gmail request to get only
visible emails.