### PR TITLE
Try to improve locale-detection.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -142,9 +142,22 @@ var Gmail_ = function(localJQuery) {
             return false;
         }
 
+        if (locale.match(/[0-9]/)) {
+            return false;
+        }
+
         var localePrefix = locale.slice(0, 2);
         return localePrefix.toLowerCase() === localePrefix ||
             localePrefix.toUpperCase() === localePrefix;
+    };
+
+    api.helper.filter_locale = function(locale) {
+        if (!api.helper.get.is_locale(locale)) {
+            return null;
+        }
+
+        // strip region-denominator
+        return locale.substring(0,2).toLowerCase();
     };
 
     api.helper.array_starts_with = function(list, item) {
@@ -213,8 +226,9 @@ var Gmail_ = function(localJQuery) {
         var localeList = api.helper.get.array_sublist(globals[17], "ui");
         if (localeList !== null && localeList.length > 8) {
             var locale = api.helper.get.locale_from_globals_item(localeList);
-            if (api.helper.get.is_locale(locale)) {
-                return locale.toLowerCase();
+            locale = api.helper.filter_locale(locale);
+            if (locale) {
+                return locale;
             }
         }
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -147,15 +147,21 @@ var Gmail_ = function(localJQuery) {
             localePrefix.toUpperCase() === localePrefix;
     };
 
-    var arrayStartsWith = function(list, item) {
-        return (list && list.length > 0 && list[0] === item);
+    api.helper.array_starts_with = function(list, item) {
+        if (list && list.length > 0 && list[0] === item) {
+            return true;
+        } else {
+            return false;
+        }
     };
 
-    var findArraySubList = function(nestedArray, itemKey) {
-        for(var i=0; i<nestedArray.length; i++) {
-            var list = nestedArray[i];
-            if (arrayStartsWith(list, itemKey)) {
-                return list;
+    api.helper.get.array_sublist = function(nestedArray, itemKey) {
+        if (nestedArray) {
+            for(var i=0; i<nestedArray.length; i++) {
+                var list = nestedArray[i];
+                if (api.helper.array_starts_with(list, itemKey)) {
+                    return list;
+                }
             }
         }
 
@@ -200,7 +206,7 @@ var Gmail_ = function(localJQuery) {
 
         // candidate is globals[17]-subarray which starts with "ui"
         // has historically been observed as [7], [8] and [9]!
-        var localeList = findArraySubList(globals[17], "ui");
+        var localeList = api.helper.get.array_sublist(globals[17], "ui");
         if (localeList !== null && localeList.length > 8) {
             var locale = getLocaleFromGlobalsItem(localeList);
             if (api.helper.get.is_locale(locale)) {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -168,7 +168,7 @@ var Gmail_ = function(localJQuery) {
         return null;
     };
 
-    var tryGetLocaleFromUrlParams = function(value) {
+    api.helper.get.locale_from_url_params = function(value) {
         // check if is URL
         if (value && value.indexOf && value.indexOf("https://") === 0) {
             var urlParts = value.split("?");
@@ -188,10 +188,14 @@ var Gmail_ = function(localJQuery) {
         return null;
     };
 
-    var getLocaleFromGlobalsItem = function(list) {
+    api.helper.get.locale_from_globals_item = function(list) {
+        if (!list) {
+            return null;
+        }
+
         for (var i=0; i<list.length; i++) {
             var item = list[i];
-            var locale = tryGetLocaleFromUrlParams(item);
+            var locale = api.helper.get.locale_from_url_params(item);
             if (locale) {
                 return locale;
             }
@@ -208,7 +212,7 @@ var Gmail_ = function(localJQuery) {
         // has historically been observed as [7], [8] and [9]!
         var localeList = api.helper.get.array_sublist(globals[17], "ui");
         if (localeList !== null && localeList.length > 8) {
-            var locale = getLocaleFromGlobalsItem(localeList);
+            var locale = api.helper.get.locale_from_globals_item(localeList);
             if (api.helper.get.is_locale(locale)) {
                 return locale.toLowerCase();
             }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -147,19 +147,32 @@ var Gmail_ = function(localJQuery) {
             localePrefix.toUpperCase() === localePrefix;
     };
 
+    var arrayStartsWith = function(list, item) {
+        return (list && list.length > 0 && list[0] === item);
+    };
+
+    var findArraySubList = function(nestedArray, itemKey) {
+        for(var i=0; i<nestedArray.length; i++) {
+            var list = nestedArray[i];
+            if (arrayStartsWith(list, itemKey)) {
+                return list;
+            }
+        }
+
+        return null;
+    };
+
     api.get.localization = function() {
         var globals = api.tracker.globals;
 
-        // First candidate.
-        var locale = globals[17] && globals[17][8] && globals[17][8][8];
-        if (api.helper.get.is_locale(locale)) {
-            return locale.toLowerCase();
-        }
-
-        // Second candidate.
-        locale = globals[17] && globals[17][9] && globals[17][9][8];
-        if (api.helper.get.is_locale(locale)) {
-            return locale.toLowerCase();
+        // candidate is globals[17]-subarray which starts with "ui"
+        // has historically been observed as [7], [8] and [9]!
+        var localeList = findArraySubList(globals[17], "ui");
+        if (localeList !== null && localeList.length > 8) {
+            var locale = localeList[8];
+            if (api.helper.get.is_locale(locale)) {
+                return locale.toLowerCase();
+            }
         }
 
         return null;

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -162,6 +162,39 @@ var Gmail_ = function(localJQuery) {
         return null;
     };
 
+    var tryGetLocaleFromUrlParams = function(value) {
+        // check if is URL
+        if (value && value.indexOf && value.indexOf("https://") === 0) {
+            var urlParts = value.split("?");
+            if (urlParts.length > 1) {
+                var hash = urlParts[1];
+                var hashParts = hash.split("&");
+                for (var i=0; i < hashParts.length; i++)
+                {
+                    var kvp = hashParts[i].split("=");
+                    if (kvp.length === 2 && kvp[0] === "hl") {
+                        return kvp[1];
+                    }
+                }
+            }
+        }
+
+        return null;
+    };
+
+    var getLocaleFromGlobalsItem = function(list) {
+        for (var i=0; i<list.length; i++) {
+            var item = list[i];
+            var locale = tryGetLocaleFromUrlParams(item);
+            if (locale) {
+                return locale;
+            }
+        }
+
+        // fallback to user-locale
+        return list[8];
+    };
+
     api.get.localization = function() {
         var globals = api.tracker.globals;
 
@@ -169,7 +202,7 @@ var Gmail_ = function(localJQuery) {
         // has historically been observed as [7], [8] and [9]!
         var localeList = findArraySubList(globals[17], "ui");
         if (localeList !== null && localeList.length > 8) {
-            var locale = localeList[8];
+            var locale = getLocaleFromGlobalsItem(localeList);
             if (api.helper.get.is_locale(locale)) {
                 return locale.toLowerCase();
             }
@@ -177,7 +210,6 @@ var Gmail_ = function(localJQuery) {
 
         return null;
     };
-
 
     api.check.is_thread = function() {
         var check_1 = $(".nH .if").children(":eq(1)").children().children(":eq(1)").children();

--- a/test/test.locale.js
+++ b/test/test.locale.js
@@ -21,6 +21,14 @@ describe("Locale-parsing", () => {
             assert.ok(!result);
         });
     });
+
+    it("Rejects badly formatted string", () => {
+        let junk = ["12", "12-23", "a3", "a45b4"];
+        junk.forEach((junkValue) => {
+            let result = gmail.helper.get.is_locale(junkValue);
+            assert.ok(!result);
+        });
+    });
 });
 
 describe("Locale URL-parsing", () => {
@@ -67,5 +75,29 @@ describe("Globals local-list parsing", () => {
 
     it("returns hl-value when URLs match", () => {
         testCase(["https://account.google.com/user/stats?firstParam=value&hl=en"], "en");
+    });
+});
+
+describe("Locale-filtering", () => {
+    let testCase = function(locale, expected) {
+        const result = gmail.helper.filter_locale(locale);
+        assert.equal(expected, result);
+    };
+
+    it("filters junk values", () => {
+        testCase(null, null);
+        testCase("", null);
+        testCase("12-23", null);
+        testCase("eN", null);
+    });
+
+    it("returned value is always lower-case", () => {
+        testCase("EN", "en");
+        testCase("en", "en");
+    });
+
+    it("returned value does not contain region-denomination", () => {
+        testCase("EN-GB", "en");
+        testCase("NO-NB", "no");
     });
 });

--- a/test/test.locale.js
+++ b/test/test.locale.js
@@ -1,10 +1,10 @@
 "use strict";
 let assert = require('assert');
 let Gmail = require('../src/gmail').Gmail;
+let gmail = new Gmail();
 
 describe("Locale-parsing", () => {
     it("Recognizes consistently cased locales", () => {
-        let gmail = new Gmail();
         let locales = ["EN","NO", "en", "no"];
 
         locales.forEach((locale) => {
@@ -14,12 +14,58 @@ describe("Locale-parsing", () => {
     });
 
     it("Rejects inconsistently cased locales", () => {
-        let gmail = new Gmail();
         let locales = ["En","No", "eN", "nO"];
 
         locales.forEach((locale) => {
             let result = gmail.helper.get.is_locale(locale);
             assert.ok(!result);
         });
+    });
+});
+
+describe("Locale URL-parsing", () => {
+    let testCase = function(url, expected) {
+        const result = gmail.helper.get.locale_from_url_params(url);
+        assert.equal(expected, result);
+    };
+
+    it("returns null from empty or null", () => {
+        testCase(null, null);
+        testCase("", null);
+    });
+
+    it("returns null from URLs with no language-code", () => {
+        testCase("https://boo/hiss", null);
+        testCase("https://account.google.com/user/stats?show=true", null);
+    });
+
+    it("returns language-codes embedded in URLs", () => {
+        testCase("https://account.google.com/user/stats?hl=en", "en");
+        testCase("https://account.google.com/user/stats?firstParam=value&hl=en", "en");
+        testCase("https://account.google.com/user/stats?foo=bar&hl=no&someMoreStuff", "no");
+    });
+});
+
+describe("Globals local-list parsing", () => {
+    let testCase = function(listlist, expected) {
+        const result = gmail.helper.get.locale_from_globals_item(listlist);
+        assert.deepEqual(expected, result);
+    };
+
+    it("returns null for null or empty list", () => {
+        testCase(null, null);
+        testCase([], null);
+    });
+
+    it("returns null for no match", () => {
+        testCase(["uiv"], null);
+    });
+
+    it("returns ui[8] when no URLs match", () => {
+        testCase(["ui", 1, 2, 3, 4, 5, 6, 7, "NO"], "NO");
+    });
+
+    it("returns hl-value when URLs match", () => {
+        testCase(["https://account.google.com/user/stats?firstParam=value&hl=en"], "en");
     });
 });

--- a/test/test.parsing.js
+++ b/test/test.parsing.js
@@ -130,3 +130,51 @@ describe("Name-parsing", () => {
         testName("Senõr Alapenõ on a stick");
     });
 });
+
+describe("List-prefix checking", () => {
+    const gmail = new Gmail();
+
+    const testCase = function(list, searchee, expected) {
+        const result = gmail.helper.array_starts_with(list, searchee);
+        assert.equal(expected, result);
+    };
+
+    it("returns false for null or empty list", () => {
+        testCase(null, "key", false);
+        testCase([], "key", false);
+    });
+
+    it("returns false for miss", () => {
+        testCase(["ui", "yes"], "uiv", false);
+    });
+
+    it("returns true for exact hit", () => {
+        testCase(["ui", "yes"], "ui", true);
+    });
+});
+
+describe("Sub-list extraction", () => {
+    const gmail = new Gmail();
+
+    const testCase = function(listlist, prefix, expected) {
+        const result = gmail.helper.get.array_sublist(listlist, prefix);
+        assert.deepEqual(expected, result);
+    };
+
+    it("returns null for null or empty list", () => {
+        testCase(null, "ui", null);
+        testCase([], "ui", null);
+    });
+
+    it("returns null for no match", () => {
+        testCase([["uiv", "a"]], "ui", null);
+    });
+
+    it("returns the full matching list on match", () => {
+        testCase([
+            ["a", "b", "c"],
+            ["ui", "yeah"],
+            ["d", "e", "f"]
+        ], "ui", ["ui", "yeah"]);
+    });
+});


### PR DESCRIPTION
As noted in the code, the globals[17] array is not entirely reliable with regard to index-based access.

I've therefore created some helper-functions to asses which sub-array is the correct one based on its key-value (which consistently has shown up as `"ui"`).

I've also applied a more intelligent approach by looking for other Google links with explicit language-codes for UI embedded in them, rather than assuming that the user's denoted locale is always applicable as a UI-language.

These language-codes *can* contain region-denominators (en-GB, etc) and for the sake of backwards compatibility, these gets filtered out.

I'm pretty sure this is 100% clean, but review would still be nice before pushing to master.

**Edit:** I've added more commits. This commit fixes #430 AND #431.