### PR TITLE
Fix ajax request error.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1637,7 +1637,7 @@ var Gmail_ = function(localJQuery) {
         method  = method || "GET";
 
         link = encodeURI(link).replace(/#-#-#/gi, "%23");
-        var config = {type: method, url: link, async: false, dataType:'text'};
+        var config = {type: method, url: link, async: false, dataType:"text"};
         if (disable_cache) {
             config.cache = false;
         }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1637,7 +1637,7 @@ var Gmail_ = function(localJQuery) {
         method  = method || "GET";
 
         link = encodeURI(link).replace(/#-#-#/gi, "%23");
-        var config = {type: method, url: link, async: false};
+        var config = {type: method, url: link, async: false, dataType:'text'};
         if (disable_cache) {
             config.cache = false;
         }


### PR DESCRIPTION
Fix ajax request: "SyntaxError: Unexpected token )", we need to specify the datatype for the response.

I am receiving a lot of errors in the console due to that problem. It isn't critical, but I recommend to fix it.

Navega, Software Developer at Appfluence Inc.