### PR TITLE
Fix: parameter "sstart" for offset.

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1766,7 +1766,7 @@ var Gmail_ = function(localJQuery) {
     api.helper.get.visible_emails_pre = function() {
         var page = api.get.current_page();
         var url = window.location.origin + window.location.pathname + "?ui=2&ik=" + api.tracker.ik+"&rid=" + api.tracker.rid + "&view=tl&num=120&rt=1";
-        var start = $(".aqK:visible .Dj").find("span:first").text().replace(",", "").replace(".", "");
+        var start = $(".aqK:visible .Dj").find("span:first").text().replace(",", "").replace(".", "").split('–')[0];
         if (start) {
             start = parseInt(start - 1);
             url += "&start=" + start +


### PR DESCRIPTION
Fix: now the parameter "sstart" is Nan, so the offset is broken, so we need to split it by "–". (i.e: "51–100").

![image](https://user-images.githubusercontent.com/16117077/35622742-306b0982-0689-11e8-80cc-0a8a4cc0e992.png)

Navega, Software Developer at Appfluence Inc.