### PR TITLE
Added support for category tabs in api.get.selected_emails_data()

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2186,7 +2186,15 @@ var Gmail = function(localJQuery) {
             if($("[gh='tl'] div[role='checkbox'][aria-checked='true']").length){
                 var email = null;
                 var emails = api.get.visible_emails(customInboxQuery);
-                $("[gh='tl'] div[role='checkbox']").each(function(index){
+
+                // Select the open tab if "Primary", "Social",
+                // and "Promotions" tabs are present
+                var emailPanel = $("[gh='tl']");
+                if (emailPanel.find("div div[role='tabpanel']").length) {
+                    emailPanel = emailPanel.find("div div[role='tabpanel']:visible");
+                }
+
+                emailPanel.find("div[role='checkbox']").each(function(index){
                     if($(this).attr("aria-checked") === "true"){
                         email = api.get.email_data(emails[index].id);
                         selected_emails.push(email);


### PR DESCRIPTION
When category tabs (see below) are present in the inbox and we call `gmail.get.selected_emails_data()`, the wrong emails are returned. This PR fixes that.

![screen shot 2018-06-21 at 6 38 14 pm](https://user-images.githubusercontent.com/2948719/41754140-bd89db00-7596-11e8-82af-d6f4322ab163.png)

`api.get.visible_emails()` returns the correct emails within `gmail.get.selected_emails_data()`, but `$("[gh='tl'] div[role='checkbox']")` selected checkboxes from all category tabs, and not just the current one, throwing off the index and thus which emails were returned from this method.

This PR may be related to #417 (which I opened a while back) and possibly #481.

I've tested this out in the old Gmail UI, new Gmail UI, and with/without category tabs. Let me know if you have any questions.

Thanks for all your work on gmail.js!