### PR TITLE
#492 - gmail.get.displayed_email_data() is not working when conversation is set "off"

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2529,10 +2529,10 @@ var Gmail = function(localJQuery) {
     var get_displayed_email_data_for_single_email = function(email_data) {
         var displayed_email_data = {};
         for (var id in email_data.threads) {
-            var message_class_id = "m"+id;
-            var displayed_email_element = $(".ii.gt .a3s.aXjCH." + message_class_id);
+            var message_class_id = id;
+            var displayed_email_element = document.querySelector("div[data-legacy-message-id='" + message_class_id + "']");
 
-            if (displayed_email_element.length > 0) {
+            if (displayed_email_element) {
                 var email = email_data.threads[id];
 
                 displayed_email_data.first_email = id;


### PR DESCRIPTION
1. Updated get_displayed_email_data_for_single_email method to fix the jquery selector not working issue in new gmail interface
2. Above fix inturn fix the issue gmail.check.is_conversation_view()