### PR TITLE
Bugfix/unread email

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -561,8 +561,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("inbox") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.split(":")[0].replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.split(":")[0].replace(/[^0-9]/g, ""));
             }
         }
 
@@ -574,8 +574,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("drafts") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -587,8 +587,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("spam") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -600,8 +600,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("forums") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -613,8 +613,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("updates") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -626,8 +626,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("promotions") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -639,8 +639,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("social_updates") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].text.indexOf("(") !== -1) {
-                return parseInt(dom[0].text.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("(") !== -1) {
+                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
             }
         }
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2630,6 +2630,18 @@ var Gmail = function(localJQuery) {
             };
             break;
 
+        case "it":
+            dictionary = {
+                "inbox": "Posta in arrivo",
+                "drafts": "Bozze",
+                "spam": "Spam",
+                "forums": "Forum",
+                "updates": "Aggiornamenti",
+                "promotions": "Promozioni",
+                "social_updates": "Social"
+            };
+            break;
+
         case "en":
         default:
             dictionary = {


### PR DESCRIPTION
In the new version (2018) of Gmail the function api.get.unread_*_emails not get the correct value of unread items, because the new version don't report in the anchor value this number, but only the label.

Digging to the DOM we can see switching from text to title is the solution, also compatible with older version too.

The fix is also apply to:
unread_draft_emails
unread_spam_emails
unread_forum_emails
unread_update_emails
unread_promotion_emails
unread_social_emails