### PR TITLE
exclude messageId with bump from predicate check

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -982,8 +982,8 @@ var Gmail = function(localJQuery) {
     api.check.data.is_email_id = function(id) {
         return id
             && typeof id === "string"
-            && /^msg-[a|f]:/.test(id)
-            && id.indexOf('bump-') === -1;
+            && id.indexOf('bump-') === -1
+            && /^msg-[a|f]:/.test(id);
     };
 
     api.check.data.is_email = function(obj) {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -982,7 +982,8 @@ var Gmail = function(localJQuery) {
     api.check.data.is_email_id = function(id) {
         return id
             && typeof id === "string"
-            && /^msg-[a|f]:/.test(id);
+            && /^msg-[a|f]:/.test(id)
+            && id.indexOf('bump-') === -1;
     };
 
     api.check.data.is_email = function(obj) {

--- a/test/test.parsing.js
+++ b/test/test.parsing.js
@@ -223,6 +223,9 @@ describe("New Gmail data-format", () => {
         assert.ok(!gmail.check.data.is_email({
             "1": "thread-a:r266633262821436756"
         }));
+        assert.ok(!gmail.check.data.is_email({
+            "1": "msg-a:bump-r266633262821436756"
+        }));
 
         assert.ok(!gmail.check.data.is_email(null));
         assert.ok(!gmail.check.data.is_email({}));
@@ -232,6 +235,11 @@ describe("New Gmail data-format", () => {
         assert.ok(!gmail.check.data.is_email({
             "1": [
                 "msg-a:r6431891629648253702"
+            ]
+        }));
+        assert.ok(!gmail.check.data.is_email({
+            "1": [
+                "msg-a:bump-r6431891629648253702"
             ]
         }));
     });

--- a/test/test.parsing.js
+++ b/test/test.parsing.js
@@ -220,6 +220,9 @@ describe("New Gmail data-format", () => {
         assert.ok(gmail.check.data.is_email({
             "1": "msg-a:r6431891629648253702"
         }));
+        assert.ok(gmail.check.data.is_email({
+            "1": "msg-f:6431891629648253702"
+        }));
         assert.ok(!gmail.check.data.is_email({
             "1": "thread-a:r266633262821436756"
         }));


### PR DESCRIPTION
When user sends an email, there are two XHR calls that would be made by the new gmail ui. My thought is there is a time buffer (depending on the user preferences) for user to undo the email and Gmail needs to know whether to send the email or not from the server side. First call is made after the user clicks send, second call is made after X seconds when user does not undo the action. 

The first `/sync` call will return an object that includes the new messageId format (`msg-[a|f]:...`) and no details on the email data. 

The second `/sync` call will include email data along with the legacy messageId (`16xxxx....`). In the email data, there is a messageId that looks something like `msg-a:bump-r-3994200xxxx....`. This is probably to tell Gmail server to actually send the email (since user does not undo it). 

Small change, is to exclude `msg-f:bump-123...` or `msg-a-:bump-r-123...` from the predicate check function. 