### PR TITLE
Fixed the issue 546

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2790,8 +2790,8 @@ var Gmail = function(localJQuery) {
     api.check.is_conversation_view = function() {
         if( api.check.is_new_data_layer() ) {
             var conversation_flag = undefined;
-            conversation_flag = api.tracker.globals[69];
-            return conversation_flag === 1 || conversation_flag === undefined;
+            conversation_flag = api.tracker.globals[24].indexOf(7164);
+            return conversation_flag !== -1;
         } else {	//To handle classic gmail UI
             var flag_name = "bx_vmb";
             var flag_value = undefined;


### PR DESCRIPTION
is_conversation_view() was not working:
Root cause of the issue:
1. is_conversation_view() is always returning true irrespective of conversation view is set to ON / OFF.
2. Gmail had changed the response in there GLOBALS variables.

Resolution:
And found that it is reflected in the array api.tracker.globals[24] has the value "7164" then conversation view is ON if it is not present in the array then it is OFF.