### PR TITLE
Fix for undefined opener

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -43,16 +43,12 @@ var Gmail = function(localJQuery) {
     api.tracker.globals   = typeof GLOBALS !== "undefined"
         ? GLOBALS
         : (
-            typeof(window) !== "undefined" && window.opener !== null && typeof window.opener.GLOBALS !== "undefined"
-                ? window.opener.GLOBALS
-                : []
+            typeof(window) !== "undefined" && window.opener && window.opener.GLOBALS || []
         );
     api.tracker.view_data = typeof VIEW_DATA !== "undefined"
         ? VIEW_DATA
         : (
-            typeof(window) !== "undefined" && window.opener !== null && typeof window.opener.VIEW_DATA !== "undefined"
-                ? window.opener.VIEW_DATA
-                : []
+            typeof(window) !== "undefined" && window.opener && window.opener.VIEW_DATA || []
         );
     api.tracker.ik        = api.tracker.globals[9] || "";
     api.tracker.hangouts  = undefined;


### PR DESCRIPTION
You can often meet in tests `window.opener === undefined`. But currently it is checked only for `window.opener !== null` and my tests is failing.