### PR TITLE
bugfixed: can't get unread emails count

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -578,24 +578,23 @@ var Gmail = function(localJQuery) {
 
 
     api.get.unread_inbox_emails = function() {
-        var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("inbox") + "']");
-
-        if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.split(":")[0].replace(/[^0-9]/g, ""));
+            var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("inbox") + "']");
+            if(dom.length > 0) {
+                if(dom[0].title.indexOf("Inbox") !== -1) {
+                    return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
+                }
             }
-        }
-
-        return 0;
-    };
-
+    
+            return 0;
+        };
+    
 
     api.get.unread_draft_emails = function() {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("drafts") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Drafts") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -607,8 +606,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("spam") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Spam") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -620,8 +619,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("forums") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Forums") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -633,8 +632,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("updates") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Updates") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -646,8 +645,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("promotions") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Promotions") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 
@@ -659,8 +658,8 @@ var Gmail = function(localJQuery) {
         var dom = $("div[role=navigation]").find("[title*='" + api.tools.i18n("social_updates") + "']");
 
         if(dom.length > 0) {
-            if(dom[0].title.indexOf("(") !== -1) {
-                return parseInt(dom[0].title.replace(/[^0-9]/g, ""));
+            if(dom[0].title.indexOf("Social") !== -1) {
+                return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
             }
         }
 


### PR DESCRIPTION
**Bug:**
All apis of getting unread emails count don't work, always return 0;

**Fixed:**
1. Change `if(dom[0].title.indexOf("(") !== -1) {` to `if(dom[0].title.indexOf("Inbox") !== -1)`, `Inbox` can be other titles

2. Change `return parseInt(dom[0].title.split(":")[0].replace(/[^0-9]/g, ""));` to `return parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));`