### PR TITLE
Replace email_id with id in thread.emails check

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1576,7 +1576,7 @@ var Gmail = function(localJQuery) {
                 }
 
                 for (let email of emails) {
-                    if (thread.emails.filter(i => i.email_id === email.email_id).length === 0) {
+                    if (thread.emails.filter(i => i.id === email.id).length === 0) {
                         thread.emails.push(email);
                     }
                 }


### PR DESCRIPTION
model returned in api.tools.parse_fd_payload does not have an email_id.  Use id instead.

const email = {
	id: fd_email_id,
	legacy_email_id: fd_legacy_email_id,
	thread_id: fd_thread_id,
	smtp_id: fd_email_smtp_id,
	subject: fd_email_subject,
	timestamp: fd_email_timestamp,
	content_html: fd_email_content_html,
	date: fd_email_date,
	from: fd_from,
	to: fd_to,
	cc: fd_cc,
	bcc: fd_bcc,
	attachments: fd_attachments
};

