### PR TITLE
Attachment URLs not working for non-primary gmail accounts

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1238,13 +1238,20 @@ var Gmail = function(localJQuery) {
                     attachment_id: item["1"]["2"],
                     name: data["3"],
                     type: data["4"],
-                    url: data["2"],
+                    url: api.tools.check_fd_attachment_url(data["2"]),
                     size: Number.parseInt(data["5"])
                 });
             }
         }
 
         return res;
+    };
+
+    api.tools.check_fd_attachment_url = function(url) {
+        var userAccountUrlPart = api.tracker.globals[7];
+        if (url.indexOf(userAccountUrlPart) < 0) {
+            url = url.replace('/mail/?', userAccountUrlPart + '?');
+        }
     };
 
     api.tools.parse_fd_request_html_payload = function(fd_email) {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1252,6 +1252,8 @@ var Gmail = function(localJQuery) {
         if (url && userAccountUrlPart && url.indexOf(userAccountUrlPart) < 0) {
             url = url.replace('/mail/?', userAccountUrlPart + '?');
         }
+
+        return url;
     };
 
     api.tools.parse_fd_request_html_payload = function(fd_email) {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1249,7 +1249,7 @@ var Gmail = function(localJQuery) {
 
     api.tools.check_fd_attachment_url = function(url) {
         var userAccountUrlPart = api.tracker.globals[7];
-        if (url.indexOf(userAccountUrlPart) < 0) {
+        if (url && userAccountUrlPart && url.indexOf(userAccountUrlPart) < 0) {
             url = url.replace('/mail/?', userAccountUrlPart + '?');
         }
     };


### PR DESCRIPTION
The attachment URL only works for the user's primary email address.  The user string /u/# must be inserted for non-primary email accounts

Both URLs work fine
https://mail.google.com/mail/?ui=2...
https://mail.google.com/mail/**u/0**?ui=2...

Only second URL works
https://mail.google.com/mail/?ui=2...
https://mail.google.com/mail/**u/1**?ui=2...
