### PR TITLE
Use top window as xhr window

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1709,27 +1709,30 @@ var Gmail = function(localJQuery) {
     };
 
     api.helper.get_xhr_window = function() {
-        var js_frame = null;
+        // var js_frame = null;
+        // if (top.document.getElementById("js_frame")){
+        //     js_frame = top.document.getElementById("js_frame");
+        // } else if (window_opener) {
+        //     js_frame = window_opener.top.document.getElementById("js_frame");
+        // }
+        // if (!js_frame){
+        //     if (window_opener) {
+        //         js_frame = window_opener.top;
+        //     } else {
+        //         js_frame = top;
+        //     }
+        // }
+        // var win;
+        // if (js_frame.contentDocument) {
+        //     win = js_frame.contentDocument.defaultView;
+        // } else {
+        //     win = js_frame;
+        // }
+        // return win;
 
-        if (top.document.getElementById("js_frame")){
-            js_frame = top.document.getElementById("js_frame");
-        } else if (window_opener) {
-            js_frame = window_opener.top.document.getElementById("js_frame");
-        }
-        if (!js_frame){
-            if (window_opener) {
-                js_frame = window_opener.top;
-            } else {
-                js_frame = top;
-            }
-        }
-        var win;
-        if (js_frame.contentDocument) {
-            win = js_frame.contentDocument.defaultView;
-        } else {
-            win = js_frame;
-        }
-        return win;
+        // in the new gmail UI, in the case of window_opener as xhr window,
+        // some events do not work, for example before_send event
+        return top;
     };
 
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1709,30 +1709,35 @@ var Gmail = function(localJQuery) {
     };
 
     api.helper.get_xhr_window = function() {
-        // var js_frame = null;
-        // if (top.document.getElementById("js_frame")){
-        //     js_frame = top.document.getElementById("js_frame");
-        // } else if (window_opener) {
-        //     js_frame = window_opener.top.document.getElementById("js_frame");
-        // }
-        // if (!js_frame){
-        //     if (window_opener) {
-        //         js_frame = window_opener.top;
-        //     } else {
-        //         js_frame = top;
-        //     }
-        // }
-        // var win;
-        // if (js_frame.contentDocument) {
-        //     win = js_frame.contentDocument.defaultView;
-        // } else {
-        //     win = js_frame;
-        // }
-        // return win;
-
         // in the new gmail UI, in the case of window_opener as xhr window,
         // some events do not work, for example before_send event
-        return top;
+        if (api.check.is_new_gui()) {
+            return top;
+        }
+
+        var js_frame = null;
+        if (top.document.getElementById("js_frame")){
+            js_frame = top.document.getElementById("js_frame");
+        } else if (window_opener) {
+            js_frame = window_opener.top.document.getElementById("js_frame");
+        }
+        
+        if (!js_frame){
+            if (window_opener) {
+                js_frame = window_opener.top;
+            } else {
+                js_frame = top;
+            }
+        }
+        
+        var win;
+        if (js_frame.contentDocument) {
+            win = js_frame.contentDocument.defaultView;
+        } else {
+            win = js_frame;
+        }
+        
+        return win;
     };
 
 


### PR DESCRIPTION
I can argue that in the new gmail UI I observe two different cases:
- the first and working case in which the `before_send_message` even works is the case when `top` window is used as a xhr window.
- the second and non-working case when `window_opener` is used as a xhr window.

The second case is reproduced very rarely and not stably. I managed to get it on my g-suite account.

I tested using only the `top` window as the xhr window, and events worked fine, even `before_send_message` event.