### PR TITLE
Silence old api deprecation warnings flag

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -54,6 +54,16 @@ var Gmail = function(localJQuery) {
         helper : {get: {}}
     };
 
+    api.DISABLE_OLD_GMAIL_API_DEPRECATION_WARNINGS = false;
+
+    function oldGmailApiDeprecated(text = "Migrate to new API compatible with new Gmail to silence this warning!") {
+        if (api.DISABLE_OLD_GMAIL_API_DEPRECATION_WARNINGS) {
+            return;
+        }
+
+        console.warn("GmailJS: using deprecated API for old Gmail.", text);
+    }
+
     api.version           = "0.8.0";
     api.tracker.globals   = typeof GLOBALS !== "undefined"
         ? GLOBALS
@@ -457,7 +467,8 @@ var Gmail = function(localJQuery) {
 
 
     api.get.email_ids = function() {
-        console.warn("GmailJS: using deprecated API for old Gmail. Migrate to new API compatible with new Gmail to silence this warning!");
+        oldGmailApiDeprecated();
+
         if(api.check.is_inside_email()) {
             var data = api.get.email_data();
             return Object.keys(data.threads);
@@ -478,7 +489,8 @@ var Gmail = function(localJQuery) {
     };
 
     api.get.thread_id = function() {
-        console.warn("GmailJS: using deprecated API for old Gmail. Migrate to new API compatible with new Gmail to silence this warning!");
+        oldGmailApiDeprecated();
+
         // multiple elements contains this attribute, but only the visible header of the visible email is a H2!
         const elem = document.querySelector("h2[data-legacy-thread-id]");
         if (elem !== null) {
@@ -491,7 +503,8 @@ var Gmail = function(localJQuery) {
     };
 
     api.get.email_id = function() {
-        console.warn("GmailJS: using deprecated API for old Gmail. Migrate to new API compatible with new Gmail to silence this warning!");
+        oldGmailApiDeprecated();
+
         return api.get.thread_id();
     };
 
@@ -3017,7 +3030,8 @@ var Gmail = function(localJQuery) {
 
 
     api.helper.get.email_data_pre = function(thread_id) {
-        console.warn("Gmail.js: Usage of legacy email-data APIs have been deprecated by Google and will most likely fail. Migrate code to use gmail.new.get.email_data() to fix this problem.");
+        oldGmailApiDeprecated("Migrate code to use gmail.new.get.email_data() to fix this problem.");
+
         if(api.check.is_inside_email() && thread_id === undefined) {
             thread_id = api.get.thread_id();
         }


### PR DESCRIPTION
You can set `Gmail.DISABLE_OLD_GMAIL_API_DEPRECATION_WARNINGS = true` to disable old gmail api deprecation warnings