### PR TITLE
api.helper.get.is_locale checks only for capitalized 2 letter strings

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -174,8 +174,8 @@ var Gmail = function(localJQuery) {
         }
 
         var localePrefix = locale.slice(0, 2);
-        return localePrefix.toLowerCase() === localePrefix ||
-            localePrefix.toUpperCase() === localePrefix;
+        return localePrefix.toUpperCase() === localePrefix;
+            
     };
 
     api.helper.filter_locale = function(locale) {


### PR DESCRIPTION
Just to clarify from the other thread, I'm assuming the intent was to check only for capitalized 2 letter strings. 

Previous behavior:

```JS
gmail.helper.get.is_locale("US");
true

gmail.helper.get.is_locale("Us");
false

gmail.helper.get.is_locale("uS");
false

gmail.helper.get.is_locale("us");
**true**
```

New behavior:

```JS
gmail.helper.get.is_locale("US");
true

gmail.helper.get.is_locale("Us");
false

gmail.helper.get.is_locale("uS");
false

gmail.helper.get.is_locale("us");
**false**
```