### PR TITLE
changed to / cc/ bcc selectors to 'input[name=bcc]' instead of textarea

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -3896,9 +3896,9 @@ var Gmail = function(localJQuery) {
         dom: function(lookup) {
             if (!lookup) return this.$el;
             var config = {
-                to:"textarea[name=to]",
-                cc:"textarea[name=cc]",
-                bcc:"textarea[name=bcc]",
+                to:"input[name=to]",
+                cc:"input[name=cc]",
+                bcc:"input[name=bcc]",
                 id: "input[name=composeid]",
                 draft: "input[name=draft]",
                 thread: "input[name=rt]",


### PR DESCRIPTION
The current selectors catch the textarea where the user types new email addresses. The existing and fully typed email addresses belong to the input element with the same name.