### PR TITLE
fix: access To, Cc, Bcc elements in new Gmail contact compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,10 @@ Returns `True` if the user is running Gmail with the new 2018 data-layer `False`
 
 Returns `True` if the user is running Gmail with the new 2018 GUI `False` otherwise
 
+#### gmail.check.is_peoplekit_compose(composeElement)
+
+Returns `True` if the compose UI uses new UI as announced [here](https://workspaceupdates.googleblog.com/2021/10/visual-updates-for-composing-email-in-gmail.html) `False` otherwise
+
 #### gmail.check.is_thread()
 
 Returns `True` if the conversation is threaded `False` otherwise

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -739,7 +739,7 @@ declare type GmailBindAction =
     | 'add_to_tasks' | 'move_label' | 'save_draft' | 'discard_draft' | 'send_message' | 'send_scheduled_message'
     | 'expand_categories' | 'delete_label' | 'show_newly_arrived_message' | 'poll'
     | 'new_email' | 'refresh' | 'open_email' | 'upload_attachment' | 'compose'
-    | 'compose_cancelled' | 'recipient_change' | 'recipient_change_new' | 'view_thread' | 'view_email'
+    | 'compose_cancelled' | 'recipient_change' | 'recipient_change' | 'view_thread' | 'view_email'
     | 'load_email_menu';
 
 interface GmailObserve {

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -739,7 +739,7 @@ declare type GmailBindAction =
     | 'add_to_tasks' | 'move_label' | 'save_draft' | 'discard_draft' | 'send_message' | 'send_scheduled_message'
     | 'expand_categories' | 'delete_label' | 'show_newly_arrived_message' | 'poll'
     | 'new_email' | 'refresh' | 'open_email' | 'upload_attachment' | 'compose'
-    | 'compose_cancelled' | 'recipient_change' | 'recipient_change' | 'view_thread' | 'view_email'
+    | 'compose_cancelled' | 'recipient_change' | 'view_thread' | 'view_email'
     | 'load_email_menu';
 
 interface GmailObserve {

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -739,7 +739,7 @@ declare type GmailBindAction =
     | 'add_to_tasks' | 'move_label' | 'save_draft' | 'discard_draft' | 'send_message' | 'send_scheduled_message'
     | 'expand_categories' | 'delete_label' | 'show_newly_arrived_message' | 'poll'
     | 'new_email' | 'refresh' | 'open_email' | 'upload_attachment' | 'compose'
-    | 'compose_cancelled' | 'recipient_change' | 'view_thread' | 'view_email'
+    | 'compose_cancelled' | 'recipient_change' | 'recipient_change_new' | 'view_thread' | 'view_email'
     | 'load_email_menu';
 
 interface GmailObserve {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -4000,7 +4000,6 @@ var Gmail = function(localJQuery) {
                     }
                 })
 
-                console.info("elems", elems)
                 const el = elems[lookup]
                 if (!el) api.tools.error("Dom lookup failed. Unable to find \"" + lookup + "\"", config, lookup);
                 return el;

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2374,16 +2374,19 @@ var Gmail = function(localJQuery) {
                         // console.log("recipient timeout handler", api.tracker.recipient_matches.length);
                         if(!api.tracker.recipient_matches.length) return;
 
-                        // determine an array of all emails specified for To, CC and BCC and extract addresses into an object for the callback
-                        let composeRoot = api.tracker.recipient_matches[0].closest("div.M9");
-                        // sometimes (on copy-paste of contact in peoplekit mode) element disappears
-                        if (composeRoot.length === 0 && api.tracker.recipient_matches.length > 0) {
-                            composeRoot = api.tracker.recipient_matches[1].closest("div.M9");
-                        }
+                        let composeRoot = [];
+                        // sometimes (on copy-paste of contact in peoplekit mode) element disappears so iterate for all matches
+                        api.tracker.recipient_matches.forEach(match => {
+                            if (composeRoot.length === 0) {
+                                composeRoot = match.closest("div.M9");
+                            }
+                        });
+
                         if (composeRoot.length === 0) {
-                            api.tools.error("Can't find composeRoot for " + match)
+                            api.tools.error("Can't find composeRoot for " + match);
                         }
                         var compose = new api.dom.compose(composeRoot);
+                        // determine an array of all emails specified for To, CC and BCC and extract addresses into an object for the callback
                         var recipients = compose.recipients();
                         callback(compose, recipients, api.tracker.recipient_matches);
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -3843,19 +3843,36 @@ var Gmail = function(localJQuery) {
         */
         recipients: function(options) {
             if( typeof options !== "object" ) options = {};
-            var name_selector = options.type ? "[name=" + options.type + "]" : "";
 
-            // determine an array of all emails specified for To, CC and BCC and extract addresses into an object for the callback
-            var recipients = options.flat ? [] : { to: [], cc: [], bcc: [] };
-            this.$el.find(".GS input[type=hidden]"+name_selector).each(function(idx, recipient ){
-                if(options.flat) {
-                    recipients.push(recipient.value);
-                } else {
-                    if(!recipients[recipient.name]) recipients[recipient.name] = [];
-                    recipients[recipient.name].push(recipient.value);
-                }
-            });
-            return recipients;
+            // Peoplekit
+            if (this.$el.find("div[data-hovercard-id]").length) {
+                let type_selector = options.type ? " div[name=" + options.type + "]" : "";
+                let recipients = options.flat ? [] : { to: [], cc: [], bcc: [] };
+                this.$el.find("tr.bzf" + type_selector + " div[data-hovercard-id]").each((_, el) => {
+                    const email = el.getAttribute("data-hovercard-id");
+                    if (options.flat) {
+                        recipients.push(email);
+                    } else {
+                        const type = el.closest("div[name]").getAttribute("name");
+                        if(!recipients[type]) recipients[type] = [];
+                        recipients[type].push(email);
+                    }
+                });
+                return recipients;
+            } else {
+                var name_selector = options.type ? "[name=" + options.type + "]" : "";
+                // determine an array of all emails specified for To, CC and BCC and extract addresses into an object for the callback
+                var recipients = options.flat ? [] : { to: [], cc: [], bcc: [] };
+                this.$el.find(".GS input[type=hidden]"+name_selector).each(function(idx, recipient ){
+                    if(options.flat) {
+                        recipients.push(recipient.value);
+                    } else {
+                        if(!recipients[recipient.name]) recipients[recipient.name] = [];
+                        recipients[recipient.name].push(recipient.value);
+                    }
+                });
+                return recipients;
+            }
         },
 
         /**
@@ -3987,19 +4004,12 @@ var Gmail = function(localJQuery) {
 
             // Post "peoplekit"
             if (this.$el.find("textarea[name=to]").length === 0 && ["to", "cc", "bcc"].includes(lookup)) {
-                const rows = this.$el.find("tr.bzf");
-                const elems = {
-                    // FIXME: It will contain localized names, not "ids"
+                const configPeoplekit = {
+                    to:"div[name=to] input",
+                    cc:"div[name=cc] input",
+                    bcc:"div[name=bcc] input"
                 };
-                rows.each((_index, e) => {
-                    const row = $(e);
-                    const label = row.find("span.gO.aQY");
-                    const input = row.find("input.agP.aFw");
-                    if (label && label.length === 1) {
-                        elems[label.html().toLowerCase()] = input;
-                    }
-                });
-                const el = elems[lookup];
+                const el = this.$el.find(configPeoplekit[lookup]);
                 if (!el) api.tools.error("Dom lookup failed. Unable to find \"" + lookup + "\"", config, lookup);
                 return el;
             }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -2375,7 +2375,14 @@ var Gmail = function(localJQuery) {
                         if(!api.tracker.recipient_matches.length) return;
 
                         // determine an array of all emails specified for To, CC and BCC and extract addresses into an object for the callback
-                        const composeRoot = api.tracker.recipient_matches[0].closest("div.M9");
+                        let composeRoot = api.tracker.recipient_matches[0].closest("div.M9");
+                        // sometimes (on copy-paste of contact in peoplekit mode) element disappears
+                        if (composeRoot.length === 0 && api.tracker.recipient_matches.length > 0) {
+                            composeRoot = api.tracker.recipient_matches[1].closest("div.M9");
+                        }
+                        if (composeRoot.length === 0) {
+                            api.tools.error("Can't find composeRoot for " + match)
+                        }
                         var compose = new api.dom.compose(composeRoot);
                         var recipients = compose.recipients();
                         callback(compose, recipients, api.tracker.recipient_matches);

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -3984,6 +3984,28 @@ var Gmail = function(localJQuery) {
                 show_cc: "span.aB.gQ.pE",
                 show_bcc: "span.aB.gQ.pB"
             };
+
+            // Post "peoplekit"
+            if (this.$el.find("textarea[name=to]").length === 0 && ["to", "cc", "bcc"].includes(lookup)) {
+                const rows = this.$el.find("tr.bzf")
+                const elems = {
+                    // FIXME: It will contain localized names, not "ids"
+                }
+                rows.each((_index, e) => {
+                    const row = $(e)
+                    const label = row.find("span.gO.aQY")
+                    const input = row.find("input.agP.aFw")
+                    if (label && label.length === 1) {
+                        elems[label.html().toLowerCase()] = input
+                    }
+                })
+
+                console.info("elems", elems)
+                const el = elems[lookup]
+                if (!el) api.tools.error("Dom lookup failed. Unable to find \"" + lookup + "\"", config, lookup);
+                return el;
+            }
+
             if(!config[lookup]) api.tools.error("Dom lookup failed. Unable to find config for \"" + lookup + "\"",config,lookup,config[lookup]);
             return this.$el.find(config[lookup]);
         }

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -300,7 +300,7 @@ var Gmail = function(localJQuery) {
     * https://workspaceupdates.googleblog.com/2021/10/visual-updates-for-composing-email-in-gmail.html
     **/ 
     api.check.is_peoplekit_compose = function (el) {
-        return !!$(el).find("div[name=to] input[peoplekit-id]").length;
+        return $(el).find("div[name=to] input[peoplekit-id]").length !== 0;
     };
 
     api.dom.inbox_content = function() {
@@ -2554,8 +2554,7 @@ var Gmail = function(localJQuery) {
                                 let observer = api.tracker.dom_observer_map["afV"];
                                 let handler = api.tracker.dom_observers.recipient_change.handler;
                                 api.observe.trigger_dom(observer, $(mutation.target), handler);
-                            }
-
+                            } else
                             if (removedNode.className === "vR") {
                                 let observer = api.tracker.dom_observer_map["vR"];
                                 let handler = api.tracker.dom_observers.recipient_change.handler;
@@ -3869,13 +3868,10 @@ var Gmail = function(localJQuery) {
             if( typeof options !== "object" ) options = {};
             const peopleKit = api.check.is_peoplekit_compose(this.$el);
             
-            const type_selector = options.type ?
-                peopleKit ?
-                    "div[name=" + options.type + "] " :
-                    "[name=" + options.type + "]" : "";
+            const type_selector = options.type ? "[name=" + options.type + "]" : "";
 
             const found = peopleKit ?
-                this.$el.find("tr.bzf " + type_selector + "div[data-hovercard-id]").map((_, el) => ({
+                this.$el.find("tr.bzf " + type_selector + " div[data-hovercard-id]").map((_, el) => ({
                     type: el.closest("div[name]").getAttribute("name"),
                     email: el.getAttribute("data-hovercard-id")
                 })) :

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -3987,20 +3987,19 @@ var Gmail = function(localJQuery) {
 
             // Post "peoplekit"
             if (this.$el.find("textarea[name=to]").length === 0 && ["to", "cc", "bcc"].includes(lookup)) {
-                const rows = this.$el.find("tr.bzf")
+                const rows = this.$el.find("tr.bzf");
                 const elems = {
                     // FIXME: It will contain localized names, not "ids"
-                }
+                };
                 rows.each((_index, e) => {
-                    const row = $(e)
-                    const label = row.find("span.gO.aQY")
-                    const input = row.find("input.agP.aFw")
+                    const row = $(e);
+                    const label = row.find("span.gO.aQY");
+                    const input = row.find("input.agP.aFw");
                     if (label && label.length === 1) {
-                        elems[label.html().toLowerCase()] = input
+                        elems[label.html().toLowerCase()] = input;
                     }
-                })
-
-                const el = elems[lookup]
+                });
+                const el = elems[lookup];
                 if (!el) api.tools.error("Dom lookup failed. Unable to find \"" + lookup + "\"", config, lookup);
                 return el;
             }


### PR DESCRIPTION
Fixes #654 

https://workspaceupdates.googleblog.com/2021/10/visual-updates-for-composing-email-in-gmail.html

* **Rapid Release Release domains**: Extended rollout (potentially longer than 15 days for feature visibility) starting on October 20, 2021. 
* **Scheduled Release domains**: Extended rollout (potentially longer than 15 days for feature visibility) beginning no earlier than November 8, 2021.

So old access need to be supported indefinitely? :(