### PR TITLE
fix: disable checking for SID, ik, act for http_event, typescript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 1.0.16
+
+- Fix `gmail.observe.on("http_event")` and `gmail.observe.after("http_event")` triggers to receive all XHR requests.
+
 ## Version 1.0.15
 
 - Fix issue with accessing to(), cc() and bcc() in compose-fields with

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ Your callback will be fired directly after Gmail's XMLHttpRequest has been sent 
 
 **Available Actions**
 
-  - **http_event** - When gmail any CRUD operation happens on gmail
+  - **http_event** - When gmail any XHR CRUD operation happens on gmail
   - **poll** - When gmail automatically polls the server to check for new emails every few seconds
   - **new_email** - When a new email appears in the inbox
   - **open_email** - When an email is opened from the inbox view
@@ -814,7 +814,7 @@ The on method also supports observering specific DOM events in the Gmail Interfa
  - **load_email_menu** - When the dropdown menu next to the reply button is clicked
 
 ```js
-gmail.observe.on("http_event", function(params) {
+gmail.observe.on("http_event", function(params, xhr) {
   console.log("url data:", params);
 })
 

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -750,6 +750,14 @@ declare type GmailBindAction =
     | 'compose_cancelled' | 'recipient_change' | 'view_thread' | 'view_email'
     | 'load_email_menu';
 
+interface HttpEventRequestParams {
+   url: object,
+   url_raw: string;
+   body: string;
+   body_params: object;
+   method: string;
+}
+
 interface GmailObserve {
     /**
        After an observer has been bound through gmail.observe.bind() (via a
@@ -778,6 +786,7 @@ interface GmailObserve {
     on(action: "load_email_menu", callback: (obj: JQuery) => void): void;
     on(action: "compose", callback: (obj: GmailDomCompose, type: GmailComposeType) => void): void;
     on(action: "load", callback: () => void): void;
+    on(action: "http_event", callback: (request: HttpEventRequestParams, xhr: XMLHttpRequest) => void): void;
     /**
        This is the key feature of gmail.js. This method allows you to
        add triggers to all of these actions so you can build your
@@ -801,6 +810,7 @@ interface GmailObserve {
       with the server response
     */
     after(action: "send_message", callback: (url: string, body: string, data: any, xhr: XMLHttpRequest) => void): void;
+    after(action: "http_event", callback: (request: HttpEventRequestParams, responseData: any, xhr: XMLHttpRequest) => void): void;
     after(action: GmailBindAction, callback: Function): void;
     /**
       Checks if a specified action & type has anything bound to it

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -964,9 +964,7 @@ var Gmail = function(localJQuery) {
             triggered[action_map[action]] = response;
         }
 
-        if(params.method === "POST" && (typeof params.url.SID === "string"
-                                       || typeof params.url.ik === "string"
-                                       || typeof params.url.act === "string")) {
+        if(params.method === "POST") {
             triggered.http_event = [params]; // send every event and all data
         }
 


### PR DESCRIPTION
Currently,  gmail.js checks for those deprecated fields (probably from old Gmail API)
as a result, there is only 2 kinds of requests which can be received by calling on("http_event") or after("http_event"): `https://mail.google.com/mail/u/0/?ui=2&ik=` and `https://mail.google.com/mail/u/0/flushimpressions?ui=2&ik=` and does not include `https://mail.google.com/mail/u/0/i/fd`- fetch mail data requests.

This PR fixes that so all other kinds of XHR requests can be accessed from gmail.js without the need to implement XHR hooks myself.