### PR TITLE
Fixed compose buttons being duplicated when using add_compose_button multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 1.0.19
+
+- Fix compose button being duplicated when using `gmail.tools.add_compose_button` more than once.
+
 ## Version 1.0.18
 
 - Fix parsing of attachments in emails form embedded JSON. Thanks @onestep!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gmail-js",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "description": "JavaScript API for Gmail (useful for chrome extensions)",
     "main": "src/gmail.js",
     "types": "src/gmail.d.ts",

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -3591,7 +3591,7 @@ var Gmail = function(localJQuery) {
 
         div.append(button);
 
-        var sendButton = composeWindow.find(".gU.Up");
+        var sendButton = composeWindow.find(".gU.Up").last();
         div.insertAfter(sendButton);
 
         return button;


### PR DESCRIPTION
I you try to add two buttons using `add_compose_button` you will get three, if you try to add three buttons, you will get 6 and so on...