### PR TITLE
Fix typing on the after send_message signature to include response

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -809,7 +809,7 @@ interface GmailObserve {
       an after event is observed when the gmail xhr request returns from the server
       with the server response
     */
-    after(action: "send_message", callback: (url: string, body: string, data: any, xhr: XMLHttpRequest) => void): void;
+    after(action: "send_message", callback: (url: string, body: string, data: any, response: any, xhr: XMLHttpRequest) => void): void;
     after(action: "http_event", callback: (request: HttpEventRequestParams, responseData: any, xhr: XMLHttpRequest) => void): void;
     after(action: GmailBindAction, callback: Function): void;
     /**


### PR DESCRIPTION
See docs here: https://github.com/KartikTalwar/gmail.js#gmailobserveafteraction-callback
and the logic here that pushes the response before the XHR object: https://github.com/KartikTalwar/gmail.js/blob/c18173c0305736ce57f016977097aa45fecd34b4/src/gmail.js#L2314