### PR TITLE
Mark identifier on email_data.new.get as optional

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -982,7 +982,7 @@ interface GmailNewGet {
      *
      * @param email_id: new style email id. Legacy IDs not supported. If empty, default to latest in view.
      */
-    email_data(identifier: GmailEmailIdentifier): GmailNewEmailData | null;
+    email_data(identifier?: GmailEmailIdentifier): GmailNewEmailData | null;
     /**
      * Returns available information about a specific thread.
      *


### PR DESCRIPTION
Makes the ts signature consistent with both the docs an the code itself: https://github.com/KartikTalwar/gmail.js/blob/c18173c0305736ce57f016977097aa45fecd34b4/src/gmail.js#L4405-L4410