### PR TITLE
Improved compose.recipients() typing

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -525,8 +525,14 @@ declare type GmailDomCompose = {
        Parameters:
        options.type  string  to, cc, or bcc to check a specific one
        options.flat  boolean if true will just return an array of all recipients instead of splitting out into to, cc, and bcc
-    */
-    recipients(options?: { type: 'to' | 'cc' | 'bcc', flat: boolean }): GmailDomComposeRecipients | string[];
+    */    /**
+     Retrieves to, cc, bcc and returns them in a hash of arrays
+     Parameters:
+     options.type  string  to, cc, or bcc to check a specific one
+     options.flat  boolean if true will just return an array of all recipients instead of splitting out into to, cc, and bcc
+     */
+    recipients(options?: { type: 'to' | 'cc' | 'bcc' }): GmailDomComposeRecipients;
+    recipients(options?: { flat: boolean }): string[];
     /**
       Retrieve the current 'to' recipients
      */

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -525,12 +525,7 @@ declare type GmailDomCompose = {
        Parameters:
        options.type  string  to, cc, or bcc to check a specific one
        options.flat  boolean if true will just return an array of all recipients instead of splitting out into to, cc, and bcc
-    */    /**
-     Retrieves to, cc, bcc and returns them in a hash of arrays
-     Parameters:
-     options.type  string  to, cc, or bcc to check a specific one
-     options.flat  boolean if true will just return an array of all recipients instead of splitting out into to, cc, and bcc
-     */
+    */
     recipients(options?: { type: 'to' | 'cc' | 'bcc' }): GmailDomComposeRecipients;
     recipients(options?: { flat: boolean }): string[];
     /**


### PR DESCRIPTION
`recipients` is expecting a `type` or `flat`, but not both. Also return type is different according to args, and not some internal logic. Therefore, its better to overload.
Note this is a breaking change: someone might have used the method with both `type` and `flat` (which would result in the latter being ignored), but I think since breaking is only for typing, its not a blocker.