### PR TITLE
Set lookup as optional on GmailDomThread.dom

### DIFF
--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -420,7 +420,7 @@ interface GmailDomThread {
     /**
        Retrieve preconfigured dom elements for this email
     */
-    dom(lookup: GmailDomThreadLookup): JQuery,
+    dom(lookup?: GmailDomThreadLookup): JQuery,
 }
 
 interface GmailDomAttachment {


### PR DESCRIPTION
Should be optional: https://github.com/KartikTalwar/gmail.js/blob/92450ed46ed20203d28529161d33ca084d1215cb/src/gmail.js#L4363-L4369