### PR TITLE
Fixed subject being returned instead of body when Mixmax is installed

### DIFF
--- a/src/gmail.js
+++ b/src/gmail.js
@@ -4131,7 +4131,7 @@ var Gmail = function(localJQuery) {
                 subject: "input[name=subject]",
                 subjectbox: "input[name=subjectbox]",
                 all_subjects: "input[name=subjectbox], input[name=subject]",
-                body: "div[contenteditable=true]",
+                body: "div[contenteditable=true]:not([id=subject])",
                 quoted_reply: "input[name=uet]",
                 reply: "M9",
                 forward: "M9",


### PR DESCRIPTION
The Mixmax extension for Gmail is changing the `subject` field from `input` to `contenteditable`, causing the `body` selector to fetch the wrong thing.

Added an extra check, to make sure we are not fetching the `subject`.