### PR TITLE
fix: Attachment URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 1.1.7
+
+- Fix for `api.tools.parse_attachment_url`.
+
 ## Version 1.1.6
 
 - Better fix for `view_thread` event not triggeriong, by @cancan101.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gmail-js",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "JavaScript API for Gmail (useful for chrome extensions)",
     "main": "src/gmail.js",
     "types": "src/gmail.d.ts",

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -1953,7 +1953,7 @@ var Gmail = function(localJQuery) {
         var parts = url.split(":");
         return {
             type: parts[0],
-            url: parts[2] + ":" + parts[3]
+            url: parts[2] + ":" + parts[4] + ":" + parts[5]
         };
     };
 


### PR DESCRIPTION
Based on https://github.com/KartikTalwar/gmail.js/issues/742