### PR TITLE
fix gmail.dom**.right_toolbar()**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 1.1.10
+
+- Fix `api.dom.right_toolbar()`, by @stevepeak.
+
 ## Version 1.1.9
 
 - Fix `api.helper.get.is_delegated_inbox`, by @moodsey211.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gmail-js",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "JavaScript API for Gmail (useful for chrome extensions)",
     "main": "src/gmail.js",
     "types": "src/gmail.d.ts",

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -421,13 +421,7 @@ var Gmail = function(localJQuery) {
     };
 
     api.dom.right_toolbar = function() {
-        var rtb = $("[gh='tm'] [gh='s']").parent();
-
-        while($(rtb).children().length === 1){
-            rtb = $(rtb).children().first();
-        }
-
-        return rtb;
+	return $("[gh='tm'] .Cr.aqJ");
     };
 
     api.check.is_inside_email = function() {

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -421,7 +421,7 @@ var Gmail = function(localJQuery) {
     };
 
     api.dom.right_toolbar = function() {
-	return $("[gh='tm'] .Cr.aqJ");
+        return $("[gh='tm'] .Cr.aqJ");
     };
 
     api.check.is_inside_email = function() {


### PR DESCRIPTION
<img width="330" alt="Screenshot 2023-02-10 at 11 54 24 AM" src="https://user-images.githubusercontent.com/2041757/218175035-670d6ab0-1111-4847-a47f-73c8b97d53be.png">

`$("[gh='tm'] [gh='s']")` does not appear to exist any more.