### PR TITLE
Fix incorrect variable name in GmailCache definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## Version 1.1.8
+
+- Fix incorrect variable name in GmailCache definition
+
 ## Version 1.1.7
 
 - Fix for `api.tools.parse_attachment_url`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gmail-js",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "JavaScript API for Gmail (useful for chrome extensions)",
     "main": "src/gmail.js",
     "types": "src/gmail.d.ts",

--- a/src/gmail.d.ts
+++ b/src/gmail.d.ts
@@ -1021,7 +1021,7 @@ interface GmailCache {
     debug_xhr_fetch: boolean;
     emailIdCache: { (emailId: string): GmailNewEmailData };
     emailLegacyIdCache: { (legacyEmailId: string): GmailNewEmailData };
-    emailThreadIdCache: { (threadId: string): GmailNewThreadData };
+    threadCache: { (threadId: string): GmailNewThreadData };
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The threadCache variable name is incorrectly defined in the d.ts file