### PR TITLE
Fix the navigation_count function and selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gmail-js",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gmail-js",
-            "version": "1.1.11",
+            "version": "1.1.12",
             "license": "MIT",
             "dependencies": {
                 "jquery": "^3.6.1"

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -636,17 +636,17 @@ var Gmail = function(localJQuery) {
 
     api.helper.get.navigation_count = function(i18nName) {
         const title = api.tools.i18n(i18nName);
-        const dom = $("div[role=navigation]").find("[title*='" + title + "']");
+        const dom = $('[aria-label*="' + title + '"]');
 
-        if (dom || dom.length > 0) {
-            // this check should implicitly always be true, but better safe than sorry?
-            if(dom[0].title.indexOf(title) !== -1) {
-                const value = parseInt(dom[0].attributes['aria-label'].value.replace(/[^0-9]/g, ""));
-                if (!isNaN(value)) {
-                    return value;
-                }
+        if (dom && dom.length > 0) {
+            const label = dom[0].attributes['aria-label'];
+            const value = parseInt(label.value.replace(/[^0-9]/g, ""));
+            if (!isNaN(value)) {
+                return value;
             }
         }
+
+        console.warn("Gmail.js: Unable to find the count for " + i18nName);
 
         return 0;
     };

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -118,7 +118,42 @@ var Gmail = function(localJQuery) {
 
 
     api.get.user_email = function() {
-        return api.tracker.globals[10];
+        const emailRegex = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/;
+
+        function extractEmail(textContent) {
+            const matches = textContent.match(emailRegex);
+            return matches && matches.length > 0 ? matches[0] : undefined;
+        }
+
+        try {
+            // First try to get the email from an element with an aria-label
+            const label = document.querySelector('[aria-label^="Google Account"]');
+            if (label) {
+                const email = extractEmail(label.textContent);
+                if (email) {
+                    return email;
+                }
+            }
+
+            // Fallback to trying to get email from HTML the <title> tag
+            // This isn't available until the page is fully loaded
+            const title = document.querySelector("title");
+            if (title) {
+                const email = extractEmail(title.textContent); // Use textContent instead of innerHTML
+                if (email) {
+                    return email;
+                }
+            }
+
+            // Log a warning if both methods fail
+            console.warn("Gmail.js: Unable to get email!");
+        } catch (err) {
+            // Log any errors encountered during the process
+            console.error("Gmail.js: Error extracting email - ", err.message);
+        }
+
+        // Return undefined or empty string if no email is found?
+        return "";
     };
 
 

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -338,7 +338,7 @@ var Gmail = function(localJQuery) {
     };
 
     api.dom.inbox_content = function() {
-        return $("div[role=main]:first");
+        return $("div[role=main]:first") && $("[aria-label='Gmail']").length;
     };
 
 
@@ -409,7 +409,7 @@ var Gmail = function(localJQuery) {
 
     api.get.storage_info = function() {
         var dom = $("[role=contentinfo] a").first();
-        var matches = dom.text().trim().match(/(\d+[.,]\d+) GB of (\d+) GB\s+\((\d+)%\)/);
+        var matches = dom.text().trim().match(/(\d+[.,]\d+) GB of (\d+) GB\s+\((\d+)\)/);
         if (matches) {
             // Replace commas with dots to handle decimal numbers correctly
             var used = parseFloat(matches[1].replace(',', '.'));

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -374,7 +374,7 @@ var Gmail = function(localJQuery) {
 
     api.get.storage_info = function() {
         var dom = $("[role=contentinfo] a").first();
-        var matches = dom.text().trim().match(/(\d+,\d+) GB of (\d+) GB\s+\((\d+)%\)/);
+        var matches = dom.text().trim().match(/(\d+[.,]\d+) GB of (\d+) GB\s+\((\d+)%\)/);
         if (matches) {
             // Replace commas with dots to handle decimal numbers correctly
             var used = parseFloat(matches[1].replace(',', '.'));

--- a/src/gmail.js
+++ b/src/gmail.js
@@ -373,11 +373,19 @@ var Gmail = function(localJQuery) {
 
 
     api.get.storage_info = function() {
-        var div = document.querySelector(".md.mj div");
-        var used = div.querySelectorAll("span")[0].textContent.replace(/,/g, '.'); //convert to standard decimal
-        var total = div.querySelectorAll("span")[1].textContent.replace(/,/g, '.');
-        var percent = parseFloat(used.replace(/[^0-9\.]/g, "")) * 100 / parseFloat(total.replace(/[^0-9\.]/g, ""));
-        return {used : used, total : total, percent : Math.floor(percent)};
+        var dom = $("[role=contentinfo] a").first();
+        var matches = dom.text().trim().match(/(\d+,\d+) GB of (\d+) GB\s+\((\d+)%\)/);
+        if (matches) {
+            // Replace commas with dots to handle decimal numbers correctly
+            var used = parseFloat(matches[1].replace(',', '.'));
+            var total = parseFloat(matches[2]); // Assuming total is always an integer, no need to replace
+            var percent = parseInt(matches[3], 10); // Base 10
+            return {used : used, total : total, percent : Math.floor(percent)};
+        } else {
+            console.warn("Gmail.js: Unable to parse storage info from the DOM");
+        }
+
+        return {used : 0, total : 0, percent : 0};
     };
 
 


### PR DESCRIPTION
This fixes two of the methods `api.helper.get.navigation_count` and `api.get.storage_info`. It returns a fair amount of data back:

```
{storage_info: 
{used: 14.32, total: 15, percent: 95},
unread_draft_emails: 152
unread_emails: {inbox: 882, drafts: 152, spam: 0, forum: 0, update: 0, …}
unread_forum_emails: 0
unread_inbox_emails: 882
unread_promotion_emails: 7
unread_social_emails: 0
unread_spam_emails: 0
unread_update_emails: 0}
```

I'm trying to target the aria labels and accessibility tags, as I think it's a better move to try to parse the page like https://testing-library.com/ library does testing. Looking at the page like a real user or a screen reader would, rather than targeting class names or such, which is a cat-and-mouse game.

I'm also doing console.warns when things aren't found for easier debugging. Throwing an error or console.error seemed a bit too much.

I'm totally open to any advice or feedback! 